### PR TITLE
Added --sample-id option to mist call

### DIFF
--- a/mist/scripts/cli.py
+++ b/mist/scripts/cli.py
@@ -89,6 +89,7 @@ def index_(
 @click.option("--export-novel", is_flag=True, help="Create FASTA files for (potential) novel alleles")
 @click.option("--keep-minimap2", is_flag=True, help="Store the minimap2 output")
 @click.option("--min-id-novel", type=int, default=99, show_default=True, help="Minimum % identity for novel alleles")
+@click.option("--sample-id", help="Sample identifier to include in the output file(s).")
 @click.option(
     "-m", "--multi", type=click.Choice([s.value for s in MultiStrategy]), default=MultiStrategy.ALL.value,
     show_default=True, help="Strategy to handle multiple perfect hits")
@@ -105,6 +106,7 @@ def call(
         threads: int,
         min_id_novel: int,
         multi: str,
+        sample_id: str | None,
         loci: str | None,
         debug: bool,
         log: Path) -> None:
@@ -145,6 +147,7 @@ def call(
         out_json=out_json_,
         out_tsv=out_tsv,
         out_dir=out_dir,
+        sample_id=sample_id,
         threads=threads
     )
     logger.info("Make sure to cite the corresponding database when using this in your research")

--- a/mist/tests/cli/test_call.py
+++ b/mist/tests/cli/test_call.py
@@ -8,6 +8,7 @@ from click.testing import CliRunner
 from mist.app.loggers.logger import initialize_logging
 from mist.app.utils import sequenceutils, testingutils
 from mist.scripts.cli import cli
+from mist.scripts.mistdists import MistDists
 from mist.scripts.mistindex import MistIndex
 
 
@@ -164,6 +165,36 @@ class TestCall(unittest.TestCase):
                 ], catch_exceptions=False
             )
             self.assertEqual(result.exit_code, 0)
+
+    def test_call_sample_id(self) -> None:
+        """
+        Tests querying the database without a sample id.
+        :return: None
+        """
+        runner = CliRunner()
+        with testingutils.get_temp_dir() as dir_temp:
+            # Output file(s)
+            dir_out = Path(dir_temp, 'out')
+            dir_out.mkdir(parents=True, exist_ok=True)
+            path_json = dir_out / 'alleles.json'
+            path_tsv = dir_out / 'alleles.tsv'
+
+            # Run the script
+            # noinspection PyTypeChecker
+            result = runner.invoke(
+                cli,[
+                    'call',
+                    '--fasta', str(files('mist').joinpath('resources/testdata/query-perfect_hits.fasta')),
+                    '--db', str(self.db_path),
+                    '--out-json', str(path_json),
+                    '--out-tsv', str(path_tsv),
+                    '--threads', '4',
+                    '--sample-id', 'my_sample_id',
+                ], catch_exceptions=False
+            )
+            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(MistDists.parse_tsv(path_tsv)[0], 'my_sample_id')
+            self.assertEqual(MistDists.parse_json(path_json)[0], 'my_sample_id')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added an option to provide a sample ID (--sample-id) to `mist call`, which is propagated to `mist dists`. This is useful when the input FASTA filename does not necessarily reflect the sample ID (e.g. in Galaxy).