### PR TITLE
 Add configurable timeout for authenticated BIGSdb downloads

### DIFF
--- a/mist/app/dbs/bigsdbauthdownloader.py
+++ b/mist/app/dbs/bigsdbauthdownloader.py
@@ -17,6 +17,7 @@ class BIGSDbAuthDownloader(BaseDownloader):
     """
 
     DOWNLOADER_KEY = 'bigsdb_auth'
+    DEFAULT_TIMEOUT = 60
 
     def __init__(self, **kwargs: Any) -> None:
         """
@@ -33,6 +34,7 @@ class BIGSDbAuthDownloader(BaseDownloader):
             raise RuntimeError(f"Required argument {err} missing")
         if self._dir_tokens is None:
             raise ValueError("Token directory should be set")
+        self._timeout: int = kwargs.get('timeout') or self.DEFAULT_TIMEOUT
 
     @property
     def path_script(self) -> str:
@@ -76,7 +78,7 @@ class BIGSDbAuthDownloader(BaseDownloader):
                 ]
             )
         )
-        command.run(self.dir_out, timeout=60)
+        command.run(self.dir_out, timeout=self._timeout)
         if not command.exit_code == 0:
             raise RuntimeError(f'Error retrieving: {url}\n{command.stderr}')
         return path_out

--- a/mist/app/dbs/bigsdbauthdownloader.py
+++ b/mist/app/dbs/bigsdbauthdownloader.py
@@ -17,7 +17,7 @@ class BIGSDbAuthDownloader(BaseDownloader):
     """
 
     DOWNLOADER_KEY = 'bigsdb_auth'
-    DEFAULT_TIMEOUT = 60
+    DEFAULT_TIMEOUT = 300
 
     def __init__(self, **kwargs: Any) -> None:
         """

--- a/mist/scripts/cli.py
+++ b/mist/scripts/cli.py
@@ -181,6 +181,13 @@ def call(
 )
 @click.option("--key-name", default="PubMLST", show_default=True, help="Key name")
 @click.option("--site", default="PubMLST", show_default=True, help="Site")
+@click.option(
+    "--timeout",
+    type=int,
+    default=60,
+    show_default=True,
+    help="Timeout (in seconds) for each download request",
+)
 @_common_options
 def download(
     url: str,
@@ -190,6 +197,7 @@ def download(
     dir_tokens: Path,
     key_name: str,
     site: str,
+    timeout: int,
     debug: bool,
     log: Path,
 ) -> None:
@@ -205,6 +213,7 @@ def download(
         dir_tokens=dir_tokens,
         key_name=key_name,
         site=site,
+        timeout=timeout,
     )
     downloader.run()
 

--- a/mist/scripts/cli.py
+++ b/mist/scripts/cli.py
@@ -184,7 +184,7 @@ def call(
 @click.option(
     "--timeout",
     type=int,
-    default=60,
+    default=300,
     show_default=True,
     help="Timeout (in seconds) for each download request",
 )

--- a/mist/scripts/mistdownload.py
+++ b/mist/scripts/mistdownload.py
@@ -17,6 +17,7 @@ class MistDownload:
         dir_tokens: Path,
         key_name: str,
         site: str,
+        timeout: int,
     ) -> None:
         """
         Initialize the scheme download class.
@@ -27,6 +28,7 @@ class MistDownload:
         :param dir_tokens: Token directory
         :param key_name: Key name
         :param site: Site name
+        :param timeout: Timeout (in seconds) for each download request
         :return: None
         """
         self._url = url
@@ -36,6 +38,7 @@ class MistDownload:
         self._dir_tokens = dir_tokens
         self._key_name = key_name
         self._site = site
+        self._timeout = timeout
 
     def run(self) -> None:
         """
@@ -47,5 +50,6 @@ class MistDownload:
             dir_tokens=self._dir_tokens,
             key_name=self._key_name,
             site=self._site,
+            timeout=self._timeout,
         )
         downloader.download_scheme(self._url, self._output, self._include_profiles)


### PR DESCRIPTION
The bigsdb_auth downloader (used for authenticated sources like BIGSdb Pasteur) ran its download helper script via a subprocess call with a hardcoded 60s timeout, which is too short for large profile/FASTA downloads.

## Changes

- Made the subprocess timeout in `BIGSDbAuthDownloader` configurable 
- Added a --timeout option to mist download, defaulting to 300s (5 min)

## Usage

```bash
mist download --url <pasteur_url> -d bigsdb_auth --timeout 1800 --include-profiles
```

closes #29 