### PR TITLE
Adds the mist lincode command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 MiST is a rapid, accurate and flexible (core-genome) multi-locus sequence typing (MLST) allele caller.
 It provides tools to download, index, and query schemes, as well as to construct (cg)MLST-based phylogenies.
 
+## LIN-codes
+
+MiST can derive [LIN codes](https://www.biorxiv.org/content/10.1101/2024.03.11.584534v1.full) from cgMLST calls from schemes hosted using BIGSdb or EnteroBase.
+More information can be found on the [Wiki](https://github.com/BioinformaticsPlatformWIV-ISP/MiST/wiki/LINcodes). 
+
 # DOCUMENTATION
 
 The documentation is available on the [Wiki](https://github.com/BioinformaticsPlatformWIV-ISP/MiST/wiki).

--- a/mist/app/dbs/basedownloader.py
+++ b/mist/app/dbs/basedownloader.py
@@ -24,6 +24,7 @@ class BaseDownloader(metaclass=abc.ABCMeta):
         :return: None
         """
         self.dir_out: Optional[Path] = None
+        self._extra_db_info: dict[str, Any] = {}
 
     @abc.abstractmethod
     def _download(self, url: str, dir_out: Path, include_profiles: bool = False) -> None:
@@ -78,6 +79,7 @@ class BaseDownloader(metaclass=abc.ABCMeta):
                     'url': url,
                     'downloader': self.DOWNLOADER_KEY,
                     'download_date': datetime.datetime.now().isoformat(),
+                    **self._extra_db_info,
                 },
                 handle,
                 indent=2,

--- a/mist/app/dbs/bigsdbauthdownloader.py
+++ b/mist/app/dbs/bigsdbauthdownloader.py
@@ -107,6 +107,8 @@ class BIGSDbAuthDownloader(BaseDownloader):
         # Download the scheme metadata
         metadata = restutils.retrieve_page_data(url).json()
         logger.info(f"Metadata received: {metadata['locus_count']:,} loci")
+        if 'lincodes' in metadata:
+            self._extra_db_info['lincodes'] = metadata['lincodes']
 
         # Create a temporary directory to store the tokens (to avoid overwriting the original files)
         dir_tokens_temp = dir_out / 'tokens'

--- a/mist/app/dbs/bigsdbdownloader.py
+++ b/mist/app/dbs/bigsdbdownloader.py
@@ -44,6 +44,8 @@ class BIGSDbDownloader(BaseDownloader):
         # Download the scheme metadata
         metadata = restutils.retrieve_page_data(url).json()
         logger.info(f"Metadata received: {metadata['locus_count']:,} loci")
+        if 'lincodes' in metadata:
+            self._extra_db_info['lincodes'] = metadata['lincodes']
 
         # Download FASTA files
         paths_fasta = self._download_fasta_files(metadata)

--- a/mist/app/errors.py
+++ b/mist/app/errors.py
@@ -5,6 +5,7 @@ class DependencyError(RuntimeError):
 
     pass
 
+
 class LinCodeError(Exception):
     """
     Raised when a LIN code cannot be extracted for the given input.

--- a/mist/app/errors.py
+++ b/mist/app/errors.py
@@ -4,3 +4,10 @@ class DependencyError(RuntimeError):
     """
 
     pass
+
+class LinCodeError(Exception):
+    """
+    Raised when a LIN code cannot be extracted for the given input.
+    """
+
+    pass

--- a/mist/app/model.py
+++ b/mist/app/model.py
@@ -4,6 +4,8 @@ from enum import Enum
 from typing import Any
 
 ALLELE_MISSING = '-'
+ALLELE_ABSENT = '0'
+ALLELE_WILDCARD = 'N'
 
 
 class CustomEncoder(json.JSONEncoder):

--- a/mist/app/query/profileindex.py
+++ b/mist/app/query/profileindex.py
@@ -1,3 +1,4 @@
+import pickle
 from collections import Counter
 from pathlib import Path
 
@@ -6,28 +7,53 @@ import pandas as pd
 from mist.app import model
 from mist.app.loggers.logger import logger
 
+NAME_INDEX = 'profile_index.pkl'
+
 
 class ProfileIndex:
     """
     Class to query profiles files with a given allele combination, using an inverted index for speed.
 
     Groups profile indices by (locus, allele) at construction time, so a query only has to look up the profiles that
-    share a detected allele at each locus, instead of comparing every profile against every queried locus.
+    share a detected allele at each locus, instead of comparing every profile against every queried locus. Since
+    building the index means reading through the whole profiles file, it can be persisted with `save` and reloaded
+    with `dir_index` instead of rebuilt on every query.
     """
 
     ALLELE_ABSENT = '0'
     ALLELE_WILDCARD = 'N'
 
-    def __init__(self, path_profiles: Path, loci: list[str]) -> None:
+    def __init__(
+        self, path_profiles: Path | None = None, loci: list[str] | None = None, dir_index: Path | None = None
+    ) -> None:
         """
-        Initializes the profile index.
-        :param path_profiles: Path to profiles file
-        :param loci: List of loci
+        Initializes the profile index, either by parsing a profiles file and building the index from scratch,
+        or by reloading a previously saved one.
+        :param path_profiles: Path to profiles file (builds the index from scratch, together with `loci`)
+        :param loci: List of loci (builds the index from scratch, together with `path_profiles`)
+        :param dir_index: Directory containing a previously saved index (see `save`), reloaded instead of rebuilt
         :return: None
         """
-        self._loci: set[str] = set(loci)
-        self._profiles: list[model.Profile] = self._parse_profiles(path_profiles, self._loci)
-        self._buckets: dict[str, dict[str, list[int]]] = self._build_buckets(self._profiles, self._loci)
+        if dir_index is not None:
+            with open(dir_index / NAME_INDEX, 'rb') as handle:
+                state = pickle.load(handle)
+            self._profiles: list[model.Profile] = state['profiles']
+            self._buckets: dict[str, dict[str, list[int]]] = state['buckets']
+            logger.debug(f'Loaded index: {len(self._profiles):,} profiles ({dir_index})')
+        else:
+            self._profiles = self._parse_profiles(path_profiles, set(loci))
+            self._buckets = self._build_buckets(self._profiles, set(loci))
+
+    def save(self, dir_out: Path) -> None:
+        """
+        Persists the index to disk, so it can be reloaded with `dir_index` instead of rebuilt on every query.
+        :param dir_out: Output directory
+        :return: None
+        """
+        dir_out.mkdir(parents=True, exist_ok=True)
+        with open(dir_out / NAME_INDEX, 'wb') as handle:
+            pickle.dump({'profiles': self._profiles, 'buckets': self._buckets}, handle)
+        logger.info(f'Profiles index saved: {dir_out / NAME_INDEX}')
 
     def _parse_profiles(self, path: Path, locus_names: set[str]) -> list[model.Profile]:
         """

--- a/mist/app/query/profileindex.py
+++ b/mist/app/query/profileindex.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 from mist.app import model
 from mist.app.loggers.logger import logger
+from mist.app.utils import alleleutils
 
 NAME_INDEX = 'profile_index.pkl'
 
@@ -18,10 +19,9 @@ class ProfileIndex:
     share a detected allele at each locus, instead of comparing every profile against every queried locus. Since
     building the index means reading through the whole profiles file, it can be persisted with `save` and reloaded
     with `dir_index` instead of rebuilt on every query.
-    """
 
-    ALLELE_ABSENT = '0'
-    ALLELE_WILDCARD = 'N'
+    Alleles are stored internally as compact int codes rather than strings.
+    """
 
     def __init__(
         self, path_profiles: Path | None = None, loci: list[str] | None = None, dir_index: Path | None = None
@@ -37,12 +37,17 @@ class ProfileIndex:
         if dir_index is not None:
             with open(dir_index / NAME_INDEX, 'rb') as handle:
                 state = pickle.load(handle)
-            self._profiles: list[model.Profile] = state['profiles']
-            self._buckets: dict[str, dict[str, list[int]]] = state['buckets']
-            logger.debug(f'Loaded index: {len(self._profiles):,} profiles ({dir_index})')
+            self._loci: list[str] = state['loci']
+            self._names: list[str] = state['names']
+            self._metadata: list[list[tuple[str, str]]] = state['metadata']
+            self._allele_codes: list[list[int]] = state['allele_codes']
+            self._buckets: dict[str, dict[int, list[int]]] = state['buckets']
+            logger.debug(f'Loaded index: {len(self._names):,} profiles ({dir_index})')
         else:
-            self._profiles = self._parse_profiles(path_profiles, set(loci))
-            self._buckets = self._build_buckets(self._profiles, set(loci))
+            self._loci, self._names, self._metadata, self._allele_codes = self._parse_profiles(
+                path_profiles, set(loci)
+            )
+            self._buckets = self._build_buckets(self._loci, self._allele_codes)
 
     def save(self, dir_out: Path) -> None:
         """
@@ -52,65 +57,69 @@ class ProfileIndex:
         """
         dir_out.mkdir(parents=True, exist_ok=True)
         with open(dir_out / NAME_INDEX, 'wb') as handle:
-            pickle.dump({'profiles': self._profiles, 'buckets': self._buckets}, handle)
+            pickle.dump(
+                {
+                    'loci': self._loci,
+                    'names': self._names,
+                    'metadata': self._metadata,
+                    'allele_codes': self._allele_codes,
+                    'buckets': self._buckets,
+                },
+                handle,
+            )
         logger.info(f'Profiles index saved: {dir_out / NAME_INDEX}')
 
-    def _parse_profiles(self, path: Path, locus_names: set[str]) -> list[model.Profile]:
+    def _parse_profiles(
+        self, path: Path, locus_names: set[str]
+    ) -> tuple[list[str], list[str], list[list[tuple[str, str]]], list[list[int]]]:
         """
         Parses the profile file.
         :param path: Path to the TSV file
         :param locus_names: Locus names
-        :return: List of profiles
+        :return: Locus names (in file column order), profile names, metadata, and encoded allele codes (one list
+            per profile, aligned to the returned locus names)
         """
-        # Parse input data
-        data_in = pd.read_table(path, dtype=str)
+        data_in = pd.read_table(path, dtype=str).fillna('n/a')
         cols_metadata = [c for c in data_in.columns if c not in locus_names]
         logger.debug(f'Metadata columns: {cols_metadata}')
         cols_alleles = [c for c in data_in.columns if c in locus_names]
         logger.debug(f'Gene columns: {cols_alleles}')
 
-        # Construct the profiles
-        profiles = []
-        for row in data_in.fillna('n/a').to_dict('records'):
-            profiles.append(
-                model.Profile(
-                    name=row[data_in.columns[0]],
-                    alleles={c: row[c] for c in cols_alleles},
-                    metadata=[(c, row[c] if not pd.isna(row[c]) else '-') for c in cols_metadata],
-                )
-            )
-        logger.debug(f'Parsed {len(profiles):,} profiles')
-        return profiles
+        names = data_in[data_in.columns[0]].tolist()
+        metadata = [list(zip(cols_metadata, row)) for row in data_in[cols_metadata].to_numpy()]
+        allele_codes = [[alleleutils.encode_allele(val) for val in row] for row in data_in[cols_alleles].to_numpy()]
+        logger.debug(f'Parsed {len(names):,} profiles')
+        return cols_alleles, names, metadata, allele_codes
 
     @staticmethod
-    def _build_buckets(profiles: list[model.Profile], loci: set[str]) -> dict[str, dict[str, list[int]]]:
+    def _build_buckets(loci: list[str], allele_codes: list[list[int]]) -> dict[str, dict[int, list[int]]]:
         """
-        Groups profile indices by (locus, allele), so a query only needs to look up the profiles that share a detected
-        allele at a given locus, instead of scanning every profile.
-        :param profiles: Profiles
-        :param loci: Locus names
-        :return: Mapping of locus -> allele -> profile indices with that allele
+        Groups profile indices by (locus, allele code), so a query only needs to look up the profiles that share a
+        detected allele at a given locus, instead of scanning every profile.
+        :param loci: Locus names, aligned to the columns of `allele_codes`
+        :param allele_codes: Encoded allele codes per profile (one list per profile, aligned to `loci`)
+        :return: Mapping of locus -> allele code -> profile indices with that code
         """
-        buckets: dict[str, dict[str, list[int]]] = {locus: {} for locus in loci}
-        for idx, profile in enumerate(profiles):
-            for locus in loci:
-                bucket = buckets[locus].setdefault(profile.alleles[locus], [])
-                bucket.append(idx)
-        logger.debug(f'Built index: {len(profiles):,} profiles, {len(loci):,} loci')
+        buckets: dict[str, dict[int, list[int]]] = {locus: {} for locus in loci}
+        for idx, codes in enumerate(allele_codes):
+            for locus, code in zip(loci, codes):
+                buckets[locus].setdefault(code, []).append(idx)
+        logger.debug(f'Built index: {len(allele_codes):,} profiles, {len(loci):,} loci')
         return buckets
 
-    @staticmethod
-    def _candidate_alleles(res: model.QueryResult | None) -> set[str]:
+    def _build_profile(self, idx: int) -> model.Profile:
         """
-        Determines which stored profile alleles a detected result could match at a single locus.
-        :param res: Detected result for the locus (None if nothing was detected)
-        :return: Candidate allele strings
+        Builds a `Profile` object for the given row index, decoding its allele codes back into strings.
+        :param idx: Row index
+        :return: Profile
         """
-        if res is None:
-            return {ProfileIndex.ALLELE_ABSENT}
-        if len(res.allele_results) == 1:
-            return {res.allele_str}
-        return set(res.allele_str.split('__'))
+        return model.Profile(
+            name=self._names[idx],
+            alleles={
+                locus: alleleutils.decode_allele(code) for locus, code in zip(self._loci, self._allele_codes[idx])
+            },
+            metadata=self._metadata[idx],
+        )
 
     def query(self, result_by_locus: dict[str, model.QueryResult | None]) -> tuple[list[model.Profile], int]:
         """
@@ -122,13 +131,13 @@ class ProfileIndex:
         for locus, res in result_by_locus.items():
             bucket = self._buckets[locus]
             # Profiles with a wildcard at this locus always match, regardless of the query
-            for allele in self._candidate_alleles(res) | {ProfileIndex.ALLELE_WILDCARD}:
-                counts.update(bucket.get(allele, []))
+            for code in alleleutils.candidate_codes(res) | {alleleutils.CODE_WILDCARD}:
+                counts.update(bucket.get(code, []))
 
         if not counts:
             # No profile matched anything (incl. wildcards) at any queried locus - nothing useful to report.
-            return [], -1 if len(self._profiles) == 0 else 0
+            return [], -1 if len(self._names) == 0 else 0
 
         best_matches = max(counts.values())
         best_indices = sorted(idx for idx, nb in counts.items() if nb == best_matches)
-        return [self._profiles[idx] for idx in best_indices], best_matches
+        return [self._build_profile(idx) for idx in best_indices], best_matches

--- a/mist/app/query/profileindex.py
+++ b/mist/app/query/profileindex.py
@@ -69,12 +69,8 @@ class ProfileIndex:
             self._buckets = self._scatter_profile_ids(dir_data, self._loci, counts_by_locus_code, len(self._names))
             with open(dir_data / NAME_META, 'wb') as handle:
                 pickle.dump(
-                    {
-                        'loci': self._loci,
-                        'names': self._names,
-                        'metadata': self._metadata,
-                        'buckets': self._buckets
-                    }, handle,
+                    {'loci': self._loci, 'names': self._names, 'metadata': self._metadata, 'buckets': self._buckets},
+                    handle,
                 )
             logger.info(f'Profile index built: {len(self._names):,} profiles ({dir_data})')
 

--- a/mist/app/query/profileindex.py
+++ b/mist/app/query/profileindex.py
@@ -22,8 +22,6 @@ class ProfileIndex:
     Groups profile indices by (locus, allele) at construction time, so a query only has to look up the profiles that
     share a detected allele at each locus, instead of comparing every profile against every queried locus.
 
-    Alleles are stored internally as compact int codes rather than strings.
-
     Both the allele codes and the index itself are backed by on-disk numpy memmaps rather than held fully in RAM
     (which would be infeasible for huge schemes).
     """
@@ -43,11 +41,11 @@ class ProfileIndex:
         """
         Initializes the profile index, either by parsing a profiles file and building the index from scratch
         (written directly to `dir_out`), or by reloading a previously built one from `dir_index`.
-        :param path_profiles: Path to profiles file (builds the index from scratch, together with `loci`/`dir_out`)
-        :param loci: List of loci (builds the index from scratch, together with `path_profiles`/`dir_out`)
-        :param dir_out: Directory to build the index into (builds the index from scratch)
-        :param dir_index: Directory containing a previously built index, reloaded instead of rebuilt
-        :param chunk_size: Nb. of profile rows to read/scatter at once while building (ignored when reloading)
+        :param path_profiles: Path to profiles file
+        :param loci: List of loci
+        :param dir_out: Directory to store the index
+        :param dir_index: Directory containing a previously built index (reload)
+        :param chunk_size: Nb. of profile rows to read/scatter while building (ignored when reloading)
         :param threads: Nb. of threads to use while building the index (ignored when reloading)
         :return: None
         """
@@ -68,7 +66,7 @@ class ProfileIndex:
             self._loci, self._names, self._metadata, counts_by_locus_code = self._parse_profiles(
                 path_profiles, set(loci), dir_data
             )
-            self._buckets = self._scatter_profile_ids(dir_data, self._loci, counts_by_locus_code)
+            self._buckets = self._scatter_profile_ids(dir_data, self._loci, counts_by_locus_code, len(self._names))
             with open(dir_data / NAME_META, 'wb') as handle:
                 pickle.dump(
                     {
@@ -89,11 +87,10 @@ class ProfileIndex:
     ) -> tuple[list[str], list[str], list[list[tuple[str, str]]], list[dict[int, int]]]:
         """
         Parses the profile file in chunks of `chunk_size` rows, writing the encoded allele codes directly into an
-        `allele_codes.npy` memmap in `dir_out` as they are read. Real cgMLST profiles files can be too large to hold as
-        a string DataFrame (or even as plain Python ints) all at once.
+        `allele_codes.npy` memmap in `dir_out` as they are read.
         :param path: Path to the TSV file
         :param locus_names: Locus names
-        :param dir_out: Output directory to write `allele_codes.npy` into
+        :param dir_out: Output directory to store memmap
         :return: Locus names (in file column order), profile names, metadata, and a tally of how many times each
             allele code occurs at each locus (one dict per locus) - used to size the buckets afterward
         """
@@ -144,26 +141,15 @@ class ProfileIndex:
         return cols_alleles, names, metadata, counts_by_locus_code
 
     def _scatter_profile_ids(
-        self, dir_out: Path, loci: list[str], counts_by_locus_code: list[dict[int, int]]
+        self, dir_out: Path, loci: list[str], counts_by_locus_code: list[dict[int, int]], nb_profiles: int
     ) -> dict[str, dict[int, tuple[int, int]]]:
         """
-        Groups profile indices by (locus, allele code) into a `profile_ids.npy` memmap in `dir_out`, so a query
-        only needs to read the (start, count) slice of one locus's column that matches a detected allele, instead
-        of scanning every profile. `profile_ids.npy` is stored column-major (Fortran order) so that slice is a
-        contiguous disk read rather than one page per row. Reads `allele_codes.npy` back in chunks of `chunk_size`
-        rows to do the scattering, rather than holding it fully in memory again.
-
-        Loci are scattered across a `threads`-sized thread pool, one batch of loci per thread rather than one
-        task per locus (submitting a fine-grained task per locus would drown the actual work in thread-pool
-        overhead). This is safe because each locus owns its own output column and cursor, and it's worth doing
-        because `_scatter_locus` below is vectorized numpy, which releases the GIL - so threads here give real
-        parallelism instead of fighting over it.
-        :param dir_out: Output directory containing `allele_codes.npy` (input) and to write `profile_ids.npy` into
+        Groups profile indices by (locus, allele code) into a `profile_ids.npy` memmap in `dir_out`.
+        :param dir_out: Output directory to store memmaps
         :param loci: Locus names, aligned to the columns of `allele_codes.npy` and `counts_by_locus_code`
-        :param counts_by_locus_code: Tally of how many times each allele code occurs at each locus (see
-            `_parse_profiles`), used to size each bucket
-        :return: Mapping of locus -> allele code -> (start, count) offset into that locus's column of
-            `profile_ids.npy`
+        :param counts_by_locus_code: Tally of how many times each allele code occurs at each locus used to size buckets
+        :param nb_profiles: Nb. of profiles parsed
+        :return: Mapping of locus -> allele code -> (start, count) offset into that locus's column of `profile_ids.npy`
         """
         buckets: dict[str, dict[int, tuple[int, int]]] = {}
         cursors: list[dict[int, int]] = []
@@ -179,7 +165,7 @@ class ProfileIndex:
             cursors.append(cursor)
 
         allele_codes = np.load(dir_out / NAME_ALLELE_CODES, mmap_mode='r')
-        nb_rows = allele_codes.shape[0]
+        nb_rows = nb_profiles
         profile_ids = np.lib.format.open_memmap(
             dir_out / NAME_PROFILE_IDS, mode='w+', dtype=np.int32, shape=(nb_rows, len(loci)), fortran_order=True
         )
@@ -208,8 +194,7 @@ class ProfileIndex:
         row_start: int,
     ) -> None:
         """
-        Scatters a batch of locus columns of one row-chunk into their bucket positions in `profile_ids`. Meant
-        to be handed a batch of loci per thread (see `_scatter_profile_ids`), not called once per locus.
+        Scatters a batch of locus columns of one row-chunk into their bucket positions in `profile_ids`.
         :param locus_indices: Column indices (loci) to scatter, within this chunk/`profile_ids`
         :param block: This chunk's rows of `allele_codes` (rows x loci)
         :param cursors: Per-locus next-free-slot-per-code, updated in place
@@ -223,11 +208,8 @@ class ProfileIndex:
     @staticmethod
     def _scatter_locus(codes: np.ndarray, cursor: dict[int, int], column: np.ndarray, row_start: int) -> None:
         """
-        Scatters one locus column of one row-chunk into its bucket positions. Vectorized rather than looping
-        over every row: a single sort groups rows by code, each row's position within its own group is computed
-        for the whole chunk at once, and the whole chunk is written to `column` in one indexed assignment - the
-        only per-row-group Python loop left is over the (few) distinct codes in this chunk, to advance the
-        cursor.
+        Scatter one locus column into bucket positions for a row chunk.
+        Vectorized over rows, only a small loop over distinct codes remains to advance cursors
         :param codes: This chunk's allele codes for one locus
         :param cursor: Next-free-slot-per-code for this locus, updated in place
         :param column: This locus's full column of `profile_ids`, written into at the computed positions
@@ -269,11 +251,6 @@ class ProfileIndex:
     def query(self, result_by_locus: dict[str, model.QueryResult | None]) -> tuple[list[model.Profile], int]:
         """
         Queries the index using the detected alleles.
-
-        Common alleles (especially the wildcard, which every locus checks unconditionally) can match tens of
-        thousands of profiles in a real scheme, so per-profile counting is done with `np.bincount` over all
-        matched indices at once, rather than incrementing a `Counter` per profile - the latter turned a fast
-        bucket lookup into a slow, unvectorized Python loop over every match.
         :param result_by_locus: Detected allele(s) by locus
         :return: Best matching profiles, nb. of matching loci
         """

--- a/mist/app/query/profileindex.py
+++ b/mist/app/query/profileindex.py
@@ -2,13 +2,16 @@ import pickle
 from collections import Counter
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 
 from mist.app import model
 from mist.app.loggers.logger import logger
-from mist.app.utils import alleleutils
+from mist.app.utils import alleleutils, tsvutils
 
-NAME_INDEX = 'profile_index.pkl'
+NAME_ALLELE_CODES = 'allele_codes.npy'
+NAME_PROFILE_IDS = 'profile_ids.npy'
+NAME_META = 'index_meta.pkl'
 
 
 class ProfileIndex:
@@ -16,95 +19,167 @@ class ProfileIndex:
     Class to query profiles files with a given allele combination, using an inverted index for speed.
 
     Groups profile indices by (locus, allele) at construction time, so a query only has to look up the profiles that
-    share a detected allele at each locus, instead of comparing every profile against every queried locus. Since
-    building the index means reading through the whole profiles file, it can be persisted with `save` and reloaded
-    with `dir_index` instead of rebuilt on every query.
+    share a detected allele at each locus, instead of comparing every profile against every queried locus.
 
     Alleles are stored internally as compact int codes rather than strings.
+
+    Both the allele codes and the index itself are backed by on-disk numpy memmaps rather than held fully in RAM
+    (which would be infeasible for huge schemes).
     """
 
+    CHUNK_SIZE = 25_000
+
     def __init__(
-        self, path_profiles: Path | None = None, loci: list[str] | None = None, dir_index: Path | None = None
+        self,
+        path_profiles: Path | None = None,
+        loci: list[str] | None = None,
+        dir_out: Path | None = None,
+        dir_index: Path | None = None,
     ) -> None:
         """
-        Initializes the profile index, either by parsing a profiles file and building the index from scratch,
-        or by reloading a previously saved one.
-        :param path_profiles: Path to profiles file (builds the index from scratch, together with `loci`)
-        :param loci: List of loci (builds the index from scratch, together with `path_profiles`)
-        :param dir_index: Directory containing a previously saved index (see `save`), reloaded instead of rebuilt
+        Initializes the profile index, either by parsing a profiles file and building the index from scratch
+        (written directly to `dir_out`), or by reloading a previously built one from `dir_index`.
+        :param path_profiles: Path to profiles file (builds the index from scratch, together with `loci`/`dir_out`)
+        :param loci: List of loci (builds the index from scratch, together with `path_profiles`/`dir_out`)
+        :param dir_out: Directory to build the index into (builds the index from scratch)
+        :param dir_index: Directory containing a previously built index, reloaded instead of rebuilt
         :return: None
         """
         if dir_index is not None:
-            with open(dir_index / NAME_INDEX, 'rb') as handle:
-                state = pickle.load(handle)
-            self._loci: list[str] = state['loci']
-            self._names: list[str] = state['names']
-            self._metadata: list[list[tuple[str, str]]] = state['metadata']
-            self._allele_codes: list[list[int]] = state['allele_codes']
-            self._buckets: dict[str, dict[int, list[int]]] = state['buckets']
-            logger.debug(f'Loaded index: {len(self._names):,} profiles ({dir_index})')
+            dir_data = dir_index
+            with open(dir_data / NAME_META, 'rb') as handle:
+                meta = pickle.load(handle)
+            self._loci: list[str] = meta['loci']
+            self._names: list[str] = meta['names']
+            self._metadata: list[list[tuple[str, str]]] = meta['metadata']
+            self._buckets: dict[str, dict[int, tuple[int, int]]] = meta['buckets']
+            logger.debug(f'Loaded index: {len(self._names):,} profiles ({dir_data})')
         else:
-            self._loci, self._names, self._metadata, self._allele_codes = self._parse_profiles(
-                path_profiles, set(loci)
+            dir_data = dir_out
+            dir_data.mkdir(parents=True, exist_ok=True)
+            self._loci, self._names, self._metadata, counts_by_locus_code = self._parse_profiles(
+                path_profiles, set(loci), dir_data
             )
-            self._buckets = self._build_buckets(self._loci, self._allele_codes)
+            self._buckets = self._scatter_profile_ids(dir_data, self._loci, counts_by_locus_code)
+            with open(dir_data / NAME_META, 'wb') as handle:
+                pickle.dump(
+                    {
+                        'loci': self._loci,
+                        'names': self._names,
+                        'metadata': self._metadata,
+                        'buckets': self._buckets
+                    }, handle,
+                )
+            logger.info(f'Profile index built: {len(self._names):,} profiles ({dir_data})')
 
-    def save(self, dir_out: Path) -> None:
-        """
-        Persists the index to disk, so it can be reloaded with `dir_index` instead of rebuilt on every query.
-        :param dir_out: Output directory
-        :return: None
-        """
-        dir_out.mkdir(parents=True, exist_ok=True)
-        with open(dir_out / NAME_INDEX, 'wb') as handle:
-            pickle.dump(
-                {
-                    'loci': self._loci,
-                    'names': self._names,
-                    'metadata': self._metadata,
-                    'allele_codes': self._allele_codes,
-                    'buckets': self._buckets,
-                },
-                handle,
-            )
-        logger.info(f'Profiles index saved: {dir_out / NAME_INDEX}')
+        self._locus_to_col: dict[str, int] = {locus: i for i, locus in enumerate(self._loci)}
+        self._allele_codes = np.load(dir_data / NAME_ALLELE_CODES, mmap_mode='r')
+        self._profile_ids = np.load(dir_data / NAME_PROFILE_IDS, mmap_mode='r')
 
     def _parse_profiles(
-        self, path: Path, locus_names: set[str]
-    ) -> tuple[list[str], list[str], list[list[tuple[str, str]]], list[list[int]]]:
+        self, path: Path, locus_names: set[str], dir_out: Path
+    ) -> tuple[list[str], list[str], list[list[tuple[str, str]]], list[dict[int, int]]]:
         """
-        Parses the profile file.
+        Parses the profile file in chunks of `CHUNK_SIZE` rows, writing the encoded allele codes directly into an
+        `allele_codes.npy` memmap in `dir_out` as they are read. Real cgMLST profiles files can be too large to hold as
+        a string DataFrame (or even as plain Python ints) all at once.
         :param path: Path to the TSV file
         :param locus_names: Locus names
-        :return: Locus names (in file column order), profile names, metadata, and encoded allele codes (one list
-            per profile, aligned to the returned locus names)
+        :param dir_out: Output directory to write `allele_codes.npy` into
+        :return: Locus names (in file column order), profile names, metadata, and a tally of how many times each
+            allele code occurs at each locus (one dict per locus) - used to size the buckets afterward
         """
-        data_in = pd.read_table(path, dtype=str).fillna('n/a')
-        cols_metadata = [c for c in data_in.columns if c not in locus_names]
+        nb_rows = tsvutils.count_rows(path)
+        logger.debug(f'Nb rows: {nb_rows:,}')
+
+        cols_header = tsvutils.parse_header(path)
+        cols_metadata: list[str] = [col for col in cols_header if col not in locus_names]
         logger.debug(f'Metadata columns: {cols_metadata}')
-        cols_alleles = [c for c in data_in.columns if c in locus_names]
+        cols_alleles: list[str] = [col for col in cols_header if col in locus_names]
         logger.debug(f'Gene columns: {cols_alleles}')
 
-        names = data_in[data_in.columns[0]].tolist()
-        metadata = [list(zip(cols_metadata, row)) for row in data_in[cols_metadata].to_numpy()]
-        allele_codes = [[alleleutils.encode_allele(val) for val in row] for row in data_in[cols_alleles].to_numpy()]
-        logger.debug(f'Parsed {len(names):,} profiles')
-        return cols_alleles, names, metadata, allele_codes
+        # Tallied to size the buckets afterward (see `_scatter_profile_ids`)
+        counts_by_locus_code: list[dict[int, int]] = [{} for _ in cols_alleles]
+
+        # A memmap needs its shape fixed at creation (requiring the nb_rows upfront)
+        allele_codes = np.lib.format.open_memmap(
+            dir_out / NAME_ALLELE_CODES, mode='w+', dtype=np.int32, shape=(nb_rows, len(cols_alleles))
+        )
+
+        names: list[str] = []
+        metadata: list[list[tuple[str, str]]] = []
+
+        nb_read = 0
+        for chunk in pd.read_table(path, dtype=str, chunksize=self.CHUNK_SIZE):
+            chunk = chunk.fillna('n/a')
+
+            names.extend(chunk[chunk.columns[0]].tolist())
+            metadata.extend(list(zip(cols_metadata, row)) for row in chunk[cols_metadata].to_numpy())
+
+            codes_chunk = np.array(
+                [[alleleutils.encode_allele(val) for val in row] for row in chunk[cols_alleles].to_numpy()],
+                dtype=np.int32,
+            )
+
+            # Write this chunk into the memmap, and tally its codes per (locus, code) - vectorized via np.unique
+            # rather than a per-cell loop, since this runs once per chunk over up to CHUNK_SIZE rows.
+            allele_codes[nb_read : nb_read + chunk.shape[0], :] = codes_chunk
+            for j, locus_counts in enumerate(counts_by_locus_code):
+                codes, counts = np.unique(codes_chunk[:, j], return_counts=True)
+                for code, count in zip(codes.tolist(), counts.tolist()):
+                    locus_counts[code] = locus_counts.get(code, 0) + count
+
+            nb_read += chunk.shape[0]
+            logger.debug(f'Parsed {nb_read:,} / {nb_rows:,} profiles')
+
+        allele_codes.flush()
+        return cols_alleles, names, metadata, counts_by_locus_code
 
     @staticmethod
-    def _build_buckets(loci: list[str], allele_codes: list[list[int]]) -> dict[str, dict[int, list[int]]]:
+    def _scatter_profile_ids(
+        dir_out: Path, loci: list[str], counts_by_locus_code: list[dict[int, int]]
+    ) -> dict[str, dict[int, tuple[int, int]]]:
         """
-        Groups profile indices by (locus, allele code), so a query only needs to look up the profiles that share a
-        detected allele at a given locus, instead of scanning every profile.
-        :param loci: Locus names, aligned to the columns of `allele_codes`
-        :param allele_codes: Encoded allele codes per profile (one list per profile, aligned to `loci`)
-        :return: Mapping of locus -> allele code -> profile indices with that code
+        Groups profile indices by (locus, allele code) into a `profile_ids.npy` memmap in `dir_out`, so a query
+        only needs to read the (start, count) slice of one locus's column that matches a detected allele, instead
+        of scanning every profile. `profile_ids.npy` is stored column-major (Fortran order) so that slice is a
+        contiguous disk read rather than one page per row. Reads `allele_codes.npy` back in chunks of `CHUNK_SIZE`
+        rows to do the scattering, rather than holding it fully in memory again.
+        :param dir_out: Output directory containing `allele_codes.npy` (input) and to write `profile_ids.npy` into
+        :param loci: Locus names, aligned to the columns of `allele_codes.npy` and `counts_by_locus_code`
+        :param counts_by_locus_code: Tally of how many times each allele code occurs at each locus (see
+            `_parse_profiles`), used to size each bucket
+        :return: Mapping of locus -> allele code -> (start, count) offset into that locus's column of
+            `profile_ids.npy`
         """
-        buckets: dict[str, dict[int, list[int]]] = {locus: {} for locus in loci}
-        for idx, codes in enumerate(allele_codes):
-            for locus, code in zip(loci, codes):
-                buckets[locus].setdefault(code, []).append(idx)
-        logger.debug(f'Built index: {len(allele_codes):,} profiles, {len(loci):,} loci')
+        buckets: dict[str, dict[int, tuple[int, int]]] = {}
+        cursors: list[dict[int, int]] = []
+        for locus, locus_counts in zip(loci, counts_by_locus_code):
+            offset = 0
+            locus_bucket: dict[int, tuple[int, int]] = {}
+            cursor: dict[int, int] = {}
+            for code, count in locus_counts.items():
+                locus_bucket[code] = (offset, count)
+                cursor[code] = offset
+                offset += count
+            buckets[locus] = locus_bucket
+            cursors.append(cursor)
+
+        allele_codes = np.load(dir_out / NAME_ALLELE_CODES, mmap_mode='r')
+        nb_rows = allele_codes.shape[0]
+        profile_ids = np.lib.format.open_memmap(
+            dir_out / NAME_PROFILE_IDS, mode='w+', dtype=np.int32, shape=(nb_rows, len(loci)), fortran_order=True
+        )
+        for row_start in range(0, nb_rows, ProfileIndex.CHUNK_SIZE):
+            row_end = min(row_start + ProfileIndex.CHUNK_SIZE, nb_rows)
+            block = allele_codes[row_start:row_end, :]
+            for j, cursor in enumerate(cursors):
+                for i, code in enumerate(block[:, j].tolist()):
+                    pos = cursor[code]
+                    profile_ids[pos, j] = row_start + i
+                    cursor[code] = pos + 1
+            logger.debug(f'Bucketed {row_end:,} / {nb_rows:,} profiles')
+        profile_ids.flush()
         return buckets
 
     def _build_profile(self, idx: int) -> model.Profile:
@@ -116,7 +191,8 @@ class ProfileIndex:
         return model.Profile(
             name=self._names[idx],
             alleles={
-                locus: alleleutils.decode_allele(code) for locus, code in zip(self._loci, self._allele_codes[idx])
+                locus: alleleutils.decode_allele(int(code))
+                for locus, code in zip(self._loci, self._allele_codes[idx, :])
             },
             metadata=self._metadata[idx],
         )
@@ -130,9 +206,13 @@ class ProfileIndex:
         counts: Counter[int] = Counter()
         for locus, res in result_by_locus.items():
             bucket = self._buckets[locus]
+            col = self._locus_to_col[locus]
             # Profiles with a wildcard at this locus always match, regardless of the query
             for code in alleleutils.candidate_codes(res) | {alleleutils.CODE_WILDCARD}:
-                counts.update(bucket.get(code, []))
+                if code not in bucket:
+                    continue
+                start, count = bucket[code]
+                counts.update(self._profile_ids[start : start + count, col].tolist())
 
         if not counts:
             # No profile matched anything (incl. wildcards) at any queried locus - nothing useful to report.

--- a/mist/app/query/profileindex.py
+++ b/mist/app/query/profileindex.py
@@ -1,5 +1,6 @@
+import concurrent.futures
+import os
 import pickle
-from collections import Counter
 from pathlib import Path
 
 import numpy as np
@@ -28,6 +29,7 @@ class ProfileIndex:
     """
 
     CHUNK_SIZE = 25_000
+    THREADS = os.cpu_count() or 1
 
     def __init__(
         self,
@@ -145,6 +147,12 @@ class ProfileIndex:
         of scanning every profile. `profile_ids.npy` is stored column-major (Fortran order) so that slice is a
         contiguous disk read rather than one page per row. Reads `allele_codes.npy` back in chunks of `CHUNK_SIZE`
         rows to do the scattering, rather than holding it fully in memory again.
+
+        Loci are scattered across a `THREADS`-sized thread pool, one batch of loci per thread rather than one
+        task per locus (submitting a fine-grained task per locus would drown the actual work in thread-pool
+        overhead). This is safe because each locus owns its own output column and cursor, and it's worth doing
+        because `_scatter_locus` below is vectorized numpy, which releases the GIL - so threads here give real
+        parallelism instead of fighting over it.
         :param dir_out: Output directory containing `allele_codes.npy` (input) and to write `profile_ids.npy` into
         :param loci: Locus names, aligned to the columns of `allele_codes.npy` and `counts_by_locus_code`
         :param counts_by_locus_code: Tally of how many times each allele code occurs at each locus (see
@@ -170,17 +178,73 @@ class ProfileIndex:
         profile_ids = np.lib.format.open_memmap(
             dir_out / NAME_PROFILE_IDS, mode='w+', dtype=np.int32, shape=(nb_rows, len(loci)), fortran_order=True
         )
-        for row_start in range(0, nb_rows, ProfileIndex.CHUNK_SIZE):
-            row_end = min(row_start + ProfileIndex.CHUNK_SIZE, nb_rows)
-            block = allele_codes[row_start:row_end, :]
-            for j, cursor in enumerate(cursors):
-                for i, code in enumerate(block[:, j].tolist()):
-                    pos = cursor[code]
-                    profile_ids[pos, j] = row_start + i
-                    cursor[code] = pos + 1
-            logger.debug(f'Bucketed {row_end:,} / {nb_rows:,} profiles')
+        locus_batches = [batch.tolist() for batch in np.array_split(np.arange(len(loci)), ProfileIndex.THREADS)]
+        with concurrent.futures.ThreadPoolExecutor(max_workers=ProfileIndex.THREADS) as executor:
+            for row_start in range(0, nb_rows, ProfileIndex.CHUNK_SIZE):
+                row_end = min(row_start + ProfileIndex.CHUNK_SIZE, nb_rows)
+                block = allele_codes[row_start:row_end, :]
+                futures = [
+                    executor.submit(ProfileIndex._scatter_locus_batch, batch, block, cursors, profile_ids, row_start)
+                    for batch in locus_batches
+                    if len(batch) > 0
+                ]
+                for future in concurrent.futures.as_completed(futures):
+                    future.result()
+                logger.debug(f'Bucketed {row_end:,} / {nb_rows:,} profiles')
         profile_ids.flush()
         return buckets
+
+    @staticmethod
+    def _scatter_locus_batch(
+        locus_indices: list[int],
+        block: np.ndarray,
+        cursors: list[dict[int, int]],
+        profile_ids: np.memmap,
+        row_start: int,
+    ) -> None:
+        """
+        Scatters a batch of locus columns of one row-chunk into their bucket positions in `profile_ids`. Meant
+        to be handed a batch of loci per thread (see `_scatter_profile_ids`), not called once per locus.
+        :param locus_indices: Column indices (loci) to scatter, within this chunk/`profile_ids`
+        :param block: This chunk's rows of `allele_codes` (rows x loci)
+        :param cursors: Per-locus next-free-slot-per-code, updated in place
+        :param profile_ids: Output memmap (rows x loci) to scatter row indices into
+        :param row_start: Global row index of the first row in `block`
+        :return: None
+        """
+        for j in locus_indices:
+            ProfileIndex._scatter_locus(block[:, j], cursors[j], profile_ids[:, j], row_start)
+
+    @staticmethod
+    def _scatter_locus(codes: np.ndarray, cursor: dict[int, int], column: np.ndarray, row_start: int) -> None:
+        """
+        Scatters one locus column of one row-chunk into its bucket positions. Vectorized rather than looping
+        over every row: a single sort groups rows by code, each row's position within its own group is computed
+        for the whole chunk at once, and the whole chunk is written to `column` in one indexed assignment - the
+        only per-row-group Python loop left is over the (few) distinct codes in this chunk, to advance the
+        cursor.
+        :param codes: This chunk's allele codes for one locus
+        :param cursor: Next-free-slot-per-code for this locus, updated in place
+        :param column: This locus's full column of `profile_ids`, written into at the computed positions
+        :param row_start: Global row index of the first row in `codes`
+        :return: None
+        """
+        # `kind='stable'` keeps rows within the same code group in their original (file) order.
+        order = np.argsort(codes, kind='stable')
+        global_rows_sorted = (row_start + order).astype(np.int32)
+        sorted_codes = codes[order]
+        unique_codes, group_starts, group_counts = np.unique(sorted_codes, return_index=True, return_counts=True)
+
+        # Rank of each row within its own code-group (0-indexed), computed for the whole chunk at once.
+        rank_within_group = np.arange(len(sorted_codes)) - np.repeat(group_starts, group_counts)
+        base_per_code = np.fromiter(
+            (cursor[int(code)] for code in unique_codes), dtype=np.int64, count=len(unique_codes)
+        )
+        dest_positions = np.repeat(base_per_code, group_counts) + rank_within_group
+
+        for code, count in zip(unique_codes.tolist(), group_counts.tolist()):
+            cursor[code] += count
+        column[dest_positions] = global_rows_sorted
 
     def _build_profile(self, idx: int) -> model.Profile:
         """
@@ -200,10 +264,15 @@ class ProfileIndex:
     def query(self, result_by_locus: dict[str, model.QueryResult | None]) -> tuple[list[model.Profile], int]:
         """
         Queries the index using the detected alleles.
+
+        Common alleles (especially the wildcard, which every locus checks unconditionally) can match tens of
+        thousands of profiles in a real scheme, so per-profile counting is done with `np.bincount` over all
+        matched indices at once, rather than incrementing a `Counter` per profile - the latter turned a fast
+        bucket lookup into a slow, unvectorized Python loop over every match.
         :param result_by_locus: Detected allele(s) by locus
         :return: Best matching profiles, nb. of matching loci
         """
-        counts: Counter[int] = Counter()
+        matched_indices: list[np.ndarray] = []
         for locus, res in result_by_locus.items():
             bucket = self._buckets[locus]
             col = self._locus_to_col[locus]
@@ -212,12 +281,13 @@ class ProfileIndex:
                 if code not in bucket:
                     continue
                 start, count = bucket[code]
-                counts.update(self._profile_ids[start : start + count, col].tolist())
+                matched_indices.append(self._profile_ids[start : start + count, col])
 
-        if not counts:
+        if not matched_indices:
             # No profile matched anything (incl. wildcards) at any queried locus - nothing useful to report.
             return [], -1 if len(self._names) == 0 else 0
 
-        best_matches = max(counts.values())
-        best_indices = sorted(idx for idx, nb in counts.items() if nb == best_matches)
-        return [self._build_profile(idx) for idx in best_indices], best_matches
+        counts = np.bincount(np.concatenate(matched_indices), minlength=len(self._names))
+        best_matches = int(counts.max())
+        best_indices = np.flatnonzero(counts == best_matches)
+        return [self._build_profile(int(idx)) for idx in best_indices], best_matches

--- a/mist/app/query/profileindex.py
+++ b/mist/app/query/profileindex.py
@@ -37,6 +37,8 @@ class ProfileIndex:
         loci: list[str] | None = None,
         dir_out: Path | None = None,
         dir_index: Path | None = None,
+        chunk_size: int = CHUNK_SIZE,
+        threads: int = THREADS,
     ) -> None:
         """
         Initializes the profile index, either by parsing a profiles file and building the index from scratch
@@ -45,6 +47,8 @@ class ProfileIndex:
         :param loci: List of loci (builds the index from scratch, together with `path_profiles`/`dir_out`)
         :param dir_out: Directory to build the index into (builds the index from scratch)
         :param dir_index: Directory containing a previously built index, reloaded instead of rebuilt
+        :param chunk_size: Nb. of profile rows to read/scatter at once while building (ignored when reloading)
+        :param threads: Nb. of threads to use while building the index (ignored when reloading)
         :return: None
         """
         if dir_index is not None:
@@ -59,6 +63,8 @@ class ProfileIndex:
         else:
             dir_data = dir_out
             dir_data.mkdir(parents=True, exist_ok=True)
+            self._chunk_size = chunk_size
+            self._threads = threads
             self._loci, self._names, self._metadata, counts_by_locus_code = self._parse_profiles(
                 path_profiles, set(loci), dir_data
             )
@@ -82,7 +88,7 @@ class ProfileIndex:
         self, path: Path, locus_names: set[str], dir_out: Path
     ) -> tuple[list[str], list[str], list[list[tuple[str, str]]], list[dict[int, int]]]:
         """
-        Parses the profile file in chunks of `CHUNK_SIZE` rows, writing the encoded allele codes directly into an
+        Parses the profile file in chunks of `chunk_size` rows, writing the encoded allele codes directly into an
         `allele_codes.npy` memmap in `dir_out` as they are read. Real cgMLST profiles files can be too large to hold as
         a string DataFrame (or even as plain Python ints) all at once.
         :param path: Path to the TSV file
@@ -112,7 +118,7 @@ class ProfileIndex:
         metadata: list[list[tuple[str, str]]] = []
 
         nb_read = 0
-        for chunk in pd.read_table(path, dtype=str, chunksize=self.CHUNK_SIZE):
+        for chunk in pd.read_table(path, dtype=str, chunksize=self._chunk_size):
             chunk = chunk.fillna('n/a')
 
             names.extend(chunk[chunk.columns[0]].tolist())
@@ -124,7 +130,7 @@ class ProfileIndex:
             )
 
             # Write this chunk into the memmap, and tally its codes per (locus, code) - vectorized via np.unique
-            # rather than a per-cell loop, since this runs once per chunk over up to CHUNK_SIZE rows.
+            # rather than a per-cell loop, since this runs once per chunk over up to chunk_size rows.
             allele_codes[nb_read : nb_read + chunk.shape[0], :] = codes_chunk
             for j, locus_counts in enumerate(counts_by_locus_code):
                 codes, counts = np.unique(codes_chunk[:, j], return_counts=True)
@@ -137,18 +143,17 @@ class ProfileIndex:
         allele_codes.flush()
         return cols_alleles, names, metadata, counts_by_locus_code
 
-    @staticmethod
     def _scatter_profile_ids(
-        dir_out: Path, loci: list[str], counts_by_locus_code: list[dict[int, int]]
+        self, dir_out: Path, loci: list[str], counts_by_locus_code: list[dict[int, int]]
     ) -> dict[str, dict[int, tuple[int, int]]]:
         """
         Groups profile indices by (locus, allele code) into a `profile_ids.npy` memmap in `dir_out`, so a query
         only needs to read the (start, count) slice of one locus's column that matches a detected allele, instead
         of scanning every profile. `profile_ids.npy` is stored column-major (Fortran order) so that slice is a
-        contiguous disk read rather than one page per row. Reads `allele_codes.npy` back in chunks of `CHUNK_SIZE`
+        contiguous disk read rather than one page per row. Reads `allele_codes.npy` back in chunks of `chunk_size`
         rows to do the scattering, rather than holding it fully in memory again.
 
-        Loci are scattered across a `THREADS`-sized thread pool, one batch of loci per thread rather than one
+        Loci are scattered across a `threads`-sized thread pool, one batch of loci per thread rather than one
         task per locus (submitting a fine-grained task per locus would drown the actual work in thread-pool
         overhead). This is safe because each locus owns its own output column and cursor, and it's worth doing
         because `_scatter_locus` below is vectorized numpy, which releases the GIL - so threads here give real
@@ -178,10 +183,10 @@ class ProfileIndex:
         profile_ids = np.lib.format.open_memmap(
             dir_out / NAME_PROFILE_IDS, mode='w+', dtype=np.int32, shape=(nb_rows, len(loci)), fortran_order=True
         )
-        locus_batches = [batch.tolist() for batch in np.array_split(np.arange(len(loci)), ProfileIndex.THREADS)]
-        with concurrent.futures.ThreadPoolExecutor(max_workers=ProfileIndex.THREADS) as executor:
-            for row_start in range(0, nb_rows, ProfileIndex.CHUNK_SIZE):
-                row_end = min(row_start + ProfileIndex.CHUNK_SIZE, nb_rows)
+        locus_batches = [batch.tolist() for batch in np.array_split(np.arange(len(loci)), self._threads)]
+        with concurrent.futures.ThreadPoolExecutor(max_workers=self._threads) as executor:
+            for row_start in range(0, nb_rows, self._chunk_size):
+                row_end = min(row_start + self._chunk_size, nb_rows)
                 block = allele_codes[row_start:row_end, :]
                 futures = [
                     executor.submit(ProfileIndex._scatter_locus_batch, batch, block, cursors, profile_ids, row_start)

--- a/mist/app/query/profileindex.py
+++ b/mist/app/query/profileindex.py
@@ -1,0 +1,108 @@
+from collections import Counter
+from pathlib import Path
+
+import pandas as pd
+
+from mist.app import model
+from mist.app.loggers.logger import logger
+
+
+class ProfileIndex:
+    """
+    Class to query profiles files with a given allele combination, using an inverted index for speed.
+
+    Groups profile indices by (locus, allele) at construction time, so a query only has to look up the profiles that
+    share a detected allele at each locus, instead of comparing every profile against every queried locus.
+    """
+
+    ALLELE_ABSENT = '0'
+    ALLELE_WILDCARD = 'N'
+
+    def __init__(self, path_profiles: Path, loci: list[str]) -> None:
+        """
+        Initializes the profile index.
+        :param path_profiles: Path to profiles file
+        :param loci: List of loci
+        :return: None
+        """
+        self._loci: set[str] = set(loci)
+        self._profiles: list[model.Profile] = self._parse_profiles(path_profiles, self._loci)
+        self._buckets: dict[str, dict[str, list[int]]] = self._build_buckets(self._profiles, self._loci)
+
+    def _parse_profiles(self, path: Path, locus_names: set[str]) -> list[model.Profile]:
+        """
+        Parses the profile file.
+        :param path: Path to the TSV file
+        :param locus_names: Locus names
+        :return: List of profiles
+        """
+        # Parse input data
+        data_in = pd.read_table(path, dtype=str)
+        cols_metadata = [c for c in data_in.columns if c not in locus_names]
+        logger.debug(f'Metadata columns: {cols_metadata}')
+        cols_alleles = [c for c in data_in.columns if c in locus_names]
+        logger.debug(f'Gene columns: {cols_alleles}')
+
+        # Construct the profiles
+        profiles = []
+        for row in data_in.fillna('n/a').to_dict('records'):
+            profiles.append(
+                model.Profile(
+                    name=row[data_in.columns[0]],
+                    alleles={c: row[c] for c in cols_alleles},
+                    metadata=[(c, row[c] if not pd.isna(row[c]) else '-') for c in cols_metadata],
+                )
+            )
+        logger.debug(f'Parsed {len(profiles):,} profiles')
+        return profiles
+
+    @staticmethod
+    def _build_buckets(profiles: list[model.Profile], loci: set[str]) -> dict[str, dict[str, list[int]]]:
+        """
+        Groups profile indices by (locus, allele), so a query only needs to look up the profiles that share a detected
+        allele at a given locus, instead of scanning every profile.
+        :param profiles: Profiles
+        :param loci: Locus names
+        :return: Mapping of locus -> allele -> profile indices with that allele
+        """
+        buckets: dict[str, dict[str, list[int]]] = {locus: {} for locus in loci}
+        for idx, profile in enumerate(profiles):
+            for locus in loci:
+                bucket = buckets[locus].setdefault(profile.alleles[locus], [])
+                bucket.append(idx)
+        logger.debug(f'Built index: {len(profiles):,} profiles, {len(loci):,} loci')
+        return buckets
+
+    @staticmethod
+    def _candidate_alleles(res: model.QueryResult | None) -> set[str]:
+        """
+        Determines which stored profile alleles a detected result could match at a single locus.
+        :param res: Detected result for the locus (None if nothing was detected)
+        :return: Candidate allele strings
+        """
+        if res is None:
+            return {ProfileIndex.ALLELE_ABSENT}
+        if len(res.allele_results) == 1:
+            return {res.allele_str}
+        return set(res.allele_str.split('__'))
+
+    def query(self, result_by_locus: dict[str, model.QueryResult | None]) -> tuple[list[model.Profile], int]:
+        """
+        Queries the index using the detected alleles.
+        :param result_by_locus: Detected allele(s) by locus
+        :return: Best matching profiles, nb. of matching loci
+        """
+        counts: Counter[int] = Counter()
+        for locus, res in result_by_locus.items():
+            bucket = self._buckets[locus]
+            # Profiles with a wildcard at this locus always match, regardless of the query
+            for allele in self._candidate_alleles(res) | {ProfileIndex.ALLELE_WILDCARD}:
+                counts.update(bucket.get(allele, []))
+
+        if not counts:
+            # No profile matched anything (incl. wildcards) at any queried locus - nothing useful to report.
+            return [], -1 if len(self._profiles) == 0 else 0
+
+        best_matches = max(counts.values())
+        best_indices = sorted(idx for idx, nb in counts.items() if nb == best_matches)
+        return [self._profiles[idx] for idx in best_indices], best_matches

--- a/mist/app/query/profilequery.py
+++ b/mist/app/query/profilequery.py
@@ -11,9 +11,6 @@ class ProfileQuery:
     Class to query profiles files with a given allele combination.
     """
 
-    ALLELE_ABSENT = '0'
-    ALLELE_WILDCARD = 'N'
-
     def __init__(self, path_profiles: Path, loci: list[str]) -> None:
         """
         Initializes the profiles query class.
@@ -61,9 +58,9 @@ class ProfileQuery:
         :param profile_allele: Profile allele
         :return: True if the alleles match, False otherwise
         """
-        if profile_allele == ProfileQuery.ALLELE_WILDCARD:
+        if profile_allele == model.ALLELE_WILDCARD:
             return True
-        if profile_allele == ProfileQuery.ALLELE_ABSENT:
+        if profile_allele == model.ALLELE_ABSENT:
             return res is None
 
         # No allele detected

--- a/mist/app/utils/alleleutils.py
+++ b/mist/app/utils/alleleutils.py
@@ -1,0 +1,53 @@
+from mist.app import model
+
+# Real allele ids are always non-negative, so these can't collide with an actual allele.
+CODE_ABSENT = 0
+CODE_WILDCARD = -1
+CODE_UNREADABLE = -2  # missing/non-numeric allele value -> never matches
+
+
+def encode_allele(raw: str) -> int:
+    """
+    Encodes an allele string into a compact int code.
+    :param raw: Allele value
+    :return: Encoded allele code
+    """
+    if raw == model.ALLELE_WILDCARD:
+        return CODE_WILDCARD
+    try:
+        return int(raw)
+    except ValueError:
+        return CODE_UNREADABLE
+
+
+def decode_allele(code: int) -> str:
+    """
+    Decodes an int allele code back into its original string representation.
+    :param code: Encoded allele
+    :return: Allele string
+    """
+    if code == CODE_WILDCARD:
+        return model.ALLELE_WILDCARD
+    if code == CODE_UNREADABLE:
+        return 'n/a'
+    return str(code)
+
+
+def candidate_codes(res: model.QueryResult | None) -> set[int]:
+    """
+    Determines which encoded allele codes a detected result could match at a single locus. Candidates that
+    aren't plain integers (e.g. a novel-allele marker like "12*") can never match a stored profile allele, so
+    they're dropped.
+    :param res: Detected result for the locus (None if nothing was detected)
+    :return: Candidate allele codes
+    """
+    if res is None:
+        return {CODE_ABSENT}
+    candidates = [res.allele_str] if len(res.allele_results) == 1 else res.allele_str.split('__')
+    codes = set()
+    for candidate in candidates:
+        try:
+            codes.add(int(candidate))
+        except ValueError:
+            continue
+    return codes

--- a/mist/app/utils/restutils.py
+++ b/mist/app/utils/restutils.py
@@ -9,18 +9,21 @@ from mist.app.utils import sequenceutils
 REQUEST_SLEEP_SECONDS = 1
 
 
-def retrieve_page_data(url: str, retries: int = 3, timeout: int = 20) -> requests.Response:
+def retrieve_page_data(
+    url: str, retries: int = 3, timeout: int = 20, auth: tuple[str, str] | None = None
+) -> requests.Response:
     """
     Retrieves data from the given URL.
     :param url: URL
     :param retries: Number of retries
     :param timeout: Timeout (in seconds)
+    :param auth: Optional (username, password) HTTP Basic auth credentials
     :return: URL data
     """
     error = None
     for retry in range(retries):
         try:
-            response = requests.get(url, timeout=timeout)
+            response = requests.get(url, timeout=timeout, auth=auth)
             response.raise_for_status()
             return response
         except requests.exceptions.RequestException as err:

--- a/mist/app/utils/tsvutils.py
+++ b/mist/app/utils/tsvutils.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+
+def count_rows(path: Path) -> int:
+    """
+    Counts the number of data rows (excluding the header) in a TSV file.
+    :param path: Path to the TSV file
+    :return: Number of data rows
+    """
+    nb_lines = 0
+    with open(path, 'rb') as handle:
+        while True:
+            buf = handle.read(1 << 20)
+            if not buf:
+                break
+            nb_lines += buf.count(b'\n')
+    return max(nb_lines - 1, 0)
+
+
+def parse_header(path: Path) -> list[str]:
+    """
+    Returns the columns for the TSV header.
+    :param path: Path
+    :return: Header
+    """
+    with path.open() as handle:
+        return handle.readline().strip().split('\t')

--- a/mist/scripts/cli.py
+++ b/mist/scripts/cli.py
@@ -202,20 +202,14 @@ def call(
     "--entero-preset",
     type=click.Choice(list(ENTEROBASE_PRESET)),
     help="EnteroBase preset supplying the API species/scheme and hierCC field (required for EnteroBase databases "
-         "unless --entero-species and --entero-scheme are both given)",
+    "unless --entero-species and --entero-scheme are both given)",
 )
-@click.option(
-    "--entero-species",
-    help="EnteroBase API species name, overriding the preset's"
-)
-@click.option(
-    "--entero-scheme",
-    help="EnteroBase API scheme name, overriding the preset's"
-)
+@click.option("--entero-species", help="EnteroBase API species name, overriding the preset's")
+@click.option("--entero-scheme", help="EnteroBase API scheme name, overriding the preset's")
 @click.option(
     "--entero-hiercc-field",
     help="EnteroBase hierCC field to derive LIN-code thresholds from (e.g. 'hierCC' or 'hierCCv0'), overriding "
-         "the preset's"
+    "the preset's",
 )
 @_common_options
 def lincode(

--- a/mist/scripts/cli.py
+++ b/mist/scripts/cli.py
@@ -9,6 +9,7 @@ import click
 from mist.app.dbs import DOWNLOADERS
 from mist.app.loggers.logger import initialize_logging, logger
 from mist.app.query.allelequeryminimap import MultiStrategy
+from mist.app.query.profileindex import ProfileIndex
 from mist.scripts.mistcaller import MistCaller
 from mist.scripts.mistdists import MistDists
 from mist.scripts.mistdownload import MistDownload
@@ -44,6 +45,18 @@ def cli() -> None:
 @click.option("-o", "--output", type=click.Path(path_type=Path), required=True, help="Output directory")
 @click.option("-c", "--cutoff", type=int, default=95, show_default=True, help="Clustering cutoff")
 @click.option("-t", "--threads", type=int, default=1, show_default=True, help="Number of threads to use")
+@click.option(
+    "--build-profile-index",
+    is_flag=True,
+    help="Build a profile index for fast ST lookups, only recommended for very large (e.g. cgMLST) schemes.",
+)
+@click.option(
+    "--chunk-size",
+    type=int,
+    default=ProfileIndex.CHUNK_SIZE,
+    show_default=True,
+    help="Nb. of profile rows to process at once when building the profile index",
+)
 @_common_options
 def index_(
     fasta: list[Path],
@@ -52,6 +65,8 @@ def index_(
     output: Path,
     cutoff: int,
     threads: int,
+    build_profile_index: bool,
+    chunk_size: int,
     debug: bool,
     log: Path,
 ) -> None:
@@ -72,8 +87,21 @@ def index_(
         raise click.UsageError("No input FASTA file(s) provided.")
 
     # Run the indexer
+    dir_out = output.expanduser().resolve()
     indexer = MistIndex(paths_fasta=paths_fasta, path_profiles=profiles, cutoff=cutoff, debug=debug)
-    indexer.create_index(dir_out=output.expanduser().resolve(), threads=threads)
+    indexer.create_index(dir_out=dir_out, threads=threads)
+
+    # Build the profile index, so profile queries don't need to scan the whole profiles file
+    if profiles is not None and build_profile_index:
+        with open(dir_out / 'loci.txt') as handle:
+            loci = [line.strip() for line in handle if line.strip()]
+        ProfileIndex(
+            path_profiles=dir_out / 'profiles.tsv',
+            loci=loci,
+            dir_out=dir_out / 'profile_index',
+            chunk_size=chunk_size,
+            threads=threads,
+        )
 
 
 @cli.command()

--- a/mist/scripts/cli.py
+++ b/mist/scripts/cli.py
@@ -14,7 +14,7 @@ from mist.scripts.mistcaller import MistCaller
 from mist.scripts.mistdists import MistDists
 from mist.scripts.mistdownload import MistDownload
 from mist.scripts.mistindex import MistIndex
-from mist.scripts.mistlincode import MistLinCode
+from mist.scripts.mistlincode import ENTEROBASE_PRESET, MistLinCode
 from mist.scripts.mistlist import MistList
 from mist.version import __version__
 
@@ -199,12 +199,23 @@ def call(
     help="Path to a file containing the EnteroBase API token (only required for EnteroBase databases)",
 )
 @click.option(
+    "--entero-preset",
+    type=click.Choice(list(ENTEROBASE_PRESET)),
+    help="EnteroBase preset supplying the API species/scheme and hierCC field (required for EnteroBase databases "
+         "unless --entero-species and --entero-scheme are both given)",
+)
+@click.option(
     "--entero-species",
-    help="EnteroBase API species name, by default it is estimated from the URL"
+    help="EnteroBase API species name, overriding the preset's"
 )
 @click.option(
     "--entero-scheme",
-    help="EnteroBase API scheme name, by default it is estimated from the URL"
+    help="EnteroBase API scheme name, overriding the preset's"
+)
+@click.option(
+    "--entero-hiercc-field",
+    help="EnteroBase hierCC field to derive LIN-code thresholds from (e.g. 'hierCC' or 'hierCCv0'), overriding "
+         "the preset's"
 )
 @_common_options
 def lincode(
@@ -212,8 +223,10 @@ def lincode(
     db: Path,
     output: Path,
     entero_token: Path | None,
+    entero_preset: str | None,
     entero_species: str | None,
     entero_scheme: str | None,
+    entero_hiercc_field: str | None,
     debug: bool,
     log: Path,
 ) -> None:
@@ -223,7 +236,12 @@ def lincode(
     initialize_logging(log_path=log, debug=debug)
     token = entero_token.read_text().strip() if entero_token is not None else None
     MistLinCode(
-        dir_db=db, entero_token=token, entero_species=entero_species, entero_scheme=entero_scheme
+        dir_db=db,
+        entero_token=token,
+        entero_preset=entero_preset,
+        entero_species=entero_species,
+        entero_scheme=entero_scheme,
+        entero_hiercc_field=entero_hiercc_field,
     ).run(mist_json, output)
 
 

--- a/mist/scripts/cli.py
+++ b/mist/scripts/cli.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import json
 from datetime import datetime
 from importlib.resources import files
 from pathlib import Path
@@ -14,6 +15,7 @@ from mist.scripts.mistcaller import MistCaller
 from mist.scripts.mistdists import MistDists
 from mist.scripts.mistdownload import MistDownload
 from mist.scripts.mistindex import MistIndex
+from mist.scripts.mistlincode import LinCodeExtractor
 from mist.scripts.mistlist import MistList
 from mist.version import __version__
 
@@ -187,6 +189,55 @@ def call(
     logger.info(f'Please cite: {path_citation.read_text()}')
     logger.info(f"Processing time: {(datetime.now() - t0).total_seconds():.2f} seconds")
 
+
+@cli.command(name='lincode')
+@click.argument('mist_json', type=click.Path(exists=True, path_type=Path))
+@click.option("-d", "--db", type=click.Path(exists=True, path_type=Path), required=True, help="Database path")
+@click.option("-o", "--output", type=click.Path(path_type=Path), required=True, help="LIN-code output JSON file")
+@click.option(
+    "--entero-token",
+    type=click.Path(exists=True, path_type=Path),
+    help="Path to a file containing the EnteroBase API token (only required for EnteroBase databases)",
+)
+@click.option(
+    "--entero-species",
+    help="EnteroBase API species name, by default it is estimated from the URL"
+)
+@click.option(
+    "--entero-scheme",
+    help="EnteroBase API scheme name, by default it is estimated from the URL"
+)
+@_common_options
+def lincode(
+    mist_json: Path,
+    db: Path,
+    output: Path,
+    entero_token: Path | None,
+    entero_species: str | None,
+    entero_scheme: str | None,
+    debug: bool,
+    log: Path,
+) -> None:
+    """
+    Extracts the LIN code for the best-matching profile in a `mist call` JSON output.
+    """
+    initialize_logging(log_path=log, debug=debug)
+    with mist_json.open() as handle:
+        data_mist = json.load(handle)
+
+    token = entero_token.read_text().strip() if entero_token is not None else None
+    result = LinCodeExtractor(
+        dir_db=db, entero_token=token, entero_species=entero_species, entero_scheme=entero_scheme
+    ).extract(data_mist)
+    with open(output, 'w') as handle:
+        json.dump(result, handle, indent=2)
+
+    # Log  the result
+    if result['lincode_partial'] is not None:
+        rendered = '-'.join(v if v is not None else '*' for v in result['lincode_partial'])
+        logger.info(f"Extracted LIN code for ST {result['st']}: {rendered}")
+    else:
+        logger.info(f"No LIN code for ST {result['st']}")
 
 @cli.command()
 @click.option("--url", required=True, help="URL to download from.")

--- a/mist/scripts/cli.py
+++ b/mist/scripts/cli.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-import json
 from datetime import datetime
 from importlib.resources import files
 from pathlib import Path
@@ -15,7 +14,7 @@ from mist.scripts.mistcaller import MistCaller
 from mist.scripts.mistdists import MistDists
 from mist.scripts.mistdownload import MistDownload
 from mist.scripts.mistindex import MistIndex
-from mist.scripts.mistlincode import LinCodeExtractor
+from mist.scripts.mistlincode import MistLinCode
 from mist.scripts.mistlist import MistList
 from mist.version import __version__
 
@@ -222,22 +221,11 @@ def lincode(
     Extracts the LIN code for the best-matching profile in a `mist call` JSON output.
     """
     initialize_logging(log_path=log, debug=debug)
-    with mist_json.open() as handle:
-        data_mist = json.load(handle)
-
     token = entero_token.read_text().strip() if entero_token is not None else None
-    result = LinCodeExtractor(
+    MistLinCode(
         dir_db=db, entero_token=token, entero_species=entero_species, entero_scheme=entero_scheme
-    ).extract(data_mist)
-    with open(output, 'w') as handle:
-        json.dump(result, handle, indent=2)
+    ).run(mist_json, output)
 
-    # Log  the result
-    if result['lincode_partial'] is not None:
-        rendered = '-'.join(v if v is not None else '*' for v in result['lincode_partial'])
-        logger.info(f"Extracted LIN code for ST {result['st']}: {rendered}")
-    else:
-        logger.info(f"No LIN code for ST {result['st']}")
 
 @cli.command()
 @click.option("--url", required=True, help="URL to download from.")

--- a/mist/scripts/mistcaller.py
+++ b/mist/scripts/mistcaller.py
@@ -12,6 +12,7 @@ from mist.app import NAME_DB_INFO, model
 from mist.app.loggers.logger import logger
 from mist.app.model import CustomEncoder
 from mist.app.query.allelequeryminimap import AlleleQueryMinimap2, MultiStrategy
+from mist.app.query.profileindex import ProfileIndex
 from mist.app.query.profilequery import ProfileQuery
 from mist.app.utils.dependencies import check_dependencies
 from mist.version import __version__
@@ -123,6 +124,29 @@ class MistCaller:
                     'fasta',
                 )
 
+    def _query_profiles(
+        self, result_by_locus: dict[str, model.QueryResult]
+    ) -> tuple[list[model.Profile], int | None]:
+        """
+        Queries the ST profiles matching the detected alleles. Prefers a prebuilt `ProfileIndex` (see `mist index
+        --build-profile-index`) over scanning `profiles.tsv` directly when one is present - only worth building
+        for very large schemes, so most databases fall back to the plain TSV scan.
+        :param result_by_locus: Detected allele(s) by locus
+        :return: Matching profile(s), and nb. of matching loci (None if this database has no profiles at all)
+        """
+        dir_profile_index = self._dir_db / 'profile_index'
+        if dir_profile_index.exists():
+            profiles, nb_matches = ProfileIndex(dir_index=dir_profile_index).query(result_by_locus)
+        elif (self._dir_db / 'profiles.tsv').exists():
+            loci = self._loci if self._loci is not None else list(result_by_locus.keys())
+            profiles, nb_matches = ProfileQuery(self._dir_db / 'profiles.tsv', loci=loci).query(result_by_locus)
+        else:
+            return [], None
+
+        if len(profiles) > 1:
+            logger.warning("Multiple equivalent matching STs detected")
+        return profiles, nb_matches
+
     def call_alleles(
         self, path_fasta: Path, out_json: Path, out_dir: Path, out_tsv: Path, sample_id: str | None, threads: int
     ) -> None:
@@ -149,18 +173,12 @@ class MistCaller:
         data_results = self._results_to_df(result_by_locus)
 
         # Query the profiles
-        if (self._dir_db / 'profiles.tsv').exists():
-            loci = self._loci if self._loci is not None else list(result_by_locus.keys())
-            profile_query = ProfileQuery(self._dir_db / 'profiles.tsv', loci=loci)
-            profiles, nb_matches = profile_query.query(result_by_locus)
+        profiles, nb_matches = self._query_profiles(result_by_locus)
+        if nb_matches is not None:
             pct_match = 100 * nb_matches / len(result_by_locus)
             logger.info(f"Matching ST(s): {', '.join([p.name for p in profiles])} ({pct_match:.2f}% match)")
-            if len(profiles) > 1:
-                logger.warning("Multiple equivalent matching STs detected")
         else:
-            profiles = []
             pct_match = None
-            nb_matches = None
 
         # Create output files
         self._export_json(

--- a/mist/scripts/mistcaller.py
+++ b/mist/scripts/mistcaller.py
@@ -124,9 +124,7 @@ class MistCaller:
                     'fasta',
                 )
 
-    def _query_profiles(
-        self, result_by_locus: dict[str, model.QueryResult]
-    ) -> tuple[list[model.Profile], int | None]:
+    def _query_profiles(self, result_by_locus: dict[str, model.QueryResult]) -> tuple[list[model.Profile], int | None]:
         """
         Queries the ST profiles matching the detected alleles. Prefers a prebuilt `ProfileIndex` (see `mist index
         --build-profile-index`) over scanning `profiles.tsv` directly when one is present - only worth building
@@ -234,11 +232,11 @@ class MistCaller:
             json.dump(
                 {
                     'alleles': {locus: dataclasses.asdict(res) for locus, res in results_by_locus.items()},
-                    'profiles': [{
-                        **dataclasses.asdict(p),
-                        'pct_match': pct_match,
-                        'nb_matches': nb_matches
-                    } for p in profiles] if len(profiles) > 0 else None,
+                    'profiles': [
+                        {**dataclasses.asdict(p), 'pct_match': pct_match, 'nb_matches': nb_matches} for p in profiles
+                    ]
+                    if len(profiles) > 0
+                    else None,
                     'metadata': {
                         'timestamp': datetime.now().isoformat(),
                         'tool_version': __version__,

--- a/mist/scripts/mistindex.py
+++ b/mist/scripts/mistindex.py
@@ -195,8 +195,13 @@ class MistIndex:
         :param dir_out: Output directory
         :return: None
         """
-        path_metadata = self._paths_fasta[0].parent / NAME_DB_INFO
-        if not path_metadata.exists():
-            logger.debug('No db_info.json file found, not copying DB metadata')
-            return
-        shutil.copyfile(path_metadata, dir_out / path_metadata.name)
+        dirs_ = [self._paths_fasta[0].parent]
+        if self._path_profiles is not None:
+            dirs_.append(self._path_profiles.parent)
+
+        for dir_candidate in dirs_:
+            path_metadata = dir_candidate / NAME_DB_INFO
+            if path_metadata.exists():
+                shutil.copyfile(path_metadata, dir_out / path_metadata.name)
+                return
+        logger.debug('No db_info.json file found, not copying DB metadata')

--- a/mist/scripts/mistlincode.py
+++ b/mist/scripts/mistlincode.py
@@ -3,13 +3,23 @@ import re
 from pathlib import Path
 from typing import Any
 
-from furl import furl
-
 from mist.app import NAME_DB_INFO, errors
 from mist.app.loggers.logger import logger
 from mist.app.utils import restutils
 
 URL_ENTEROBASE_API = 'https://enterobase.warwick.ac.uk/api/v2.0'
+ENTEROBASE_PRESET = {
+    'ecoli': {
+        'species': 'ecoli',
+        'scheme': 'cgMLST',
+        'hiercc_field': 'hierCC',
+    },
+    'salmonella': {
+        'species': 'senterica',
+        'scheme': 'cgMLST_v2',
+        'hiercc_field': 'hierCCv0',
+    },
+}
 
 
 class MistLinCode:
@@ -25,20 +35,26 @@ class MistLinCode:
         self,
         dir_db: Path,
         entero_token: str | None = None,
+        entero_preset: str | None = None,
         entero_species: str | None = None,
         entero_scheme: str | None = None,
+        entero_hiercc_field: str | None = None,
     ) -> None:
         """
         Initializes the extractor.
         :param dir_db: Database directory (indexed by `mist index`)
         :param entero_token: EnteroBase API token
-        :param entero_species: EnteroBase API species name
-        :param entero_scheme: EnteroBase API scheme name
+        :param entero_preset: EnteroBase preset name
+        :param entero_species: EnteroBase API species name (can override the preset)
+        :param entero_scheme: EnteroBase API scheme name (can override the preset)
+        :param entero_hiercc_field: EnteroBase hierCC field to derive thresholds (can override the preset)
         :return: None
         """
         self._entero_token = entero_token
+        self._entero_preset = entero_preset
         self._entero_species = entero_species
         self._entero_scheme = entero_scheme
+        self._entero_hiercc_field = entero_hiercc_field
         path_db_info = dir_db / NAME_DB_INFO
         if not path_db_info.exists():
             raise errors.LinCodeError(
@@ -137,25 +153,21 @@ class MistLinCode:
         if not self._entero_token:
             raise errors.LinCodeError('An EnteroBase API token is required to extract LIN codes for this database')
 
-        species_guess, scheme_guess = _entero_species_scheme(self._db_info['url'])
-        species = self._entero_species or species_guess
-        scheme = self._entero_scheme or scheme_guess
+        species, scheme, hiercc_field = self._resolve_entero_params()
         st_id = profile['name']
         url = f'{URL_ENTEROBASE_API}/{species}/{scheme}/sts?limit=1&offset=0&st_id={st_id}&scheme={scheme}'
         sts = restutils.retrieve_page_data(url, auth=(self._entero_token, '')).json().get('STs', [])
         if not sts:
             raise errors.LinCodeError(
                 f"No LIN code found for ST {st_id} at {url} - the species/scheme slug ('{species}'/'{scheme}') "
-                f"may be wrong for this database; override with --entero-species/--entero-scheme if so "
-                f"(EnteroBase's API naming doesn't reliably match its download URLs)"
+                f"may be wrong for this database; select the right --entero-preset, or override the slugs with "
+                f"--entero-species/--entero-scheme"
             )
         info = sts[0]['info']
         lincode_full = _split_lincode(info['lin_code'])
         nb_matches, nb_loci = profile['nb_matches'], len(profile['alleles'])
 
-        # Prefer 'hierCCv0' over 'hierCC'
-        hiercc_raw = info.get('hierCCv0') or info.get('hierCC', {})
-        thresholds = _entero_hiercc_thresholds(hiercc_raw)
+        thresholds = _entero_hiercc_thresholds(_select_hiercc(info, hiercc_field))
         if len(thresholds) == len(lincode_full):
             nb_assigned = _determine_bin(nb_loci - nb_matches, thresholds)
             lincode_partial = _mask_lincode(lincode_full, nb_assigned)
@@ -174,6 +186,39 @@ class MistLinCode:
             'lincode_partial': lincode_partial,
             'thresholds': thresholds,
         }
+
+    def _resolve_entero_params(self) -> tuple[str, str, str | None]:
+        """
+        Resolves the EnteroBase API species/scheme slugs and the hierCC field to derive thresholds from. Values
+        come from the selected preset (`--entero-preset`), each overridable individually from the CLI. Nothing is
+        guessed from the download URL: the species and scheme must be pinned down by a preset or by explicit
+        overrides, or extraction raises rather than querying a guessed endpoint.
+        :return: (species, scheme, hiercc_field) - hiercc_field may be None if neither a preset nor an override set it
+        """
+        preset = self._entero_preset_values()
+        species = self._entero_species or preset.get('species')
+        scheme = self._entero_scheme or preset.get('scheme')
+        hiercc_field = self._entero_hiercc_field or preset.get('hiercc_field')
+        if not species or not scheme:
+            raise errors.LinCodeError(
+                'EnteroBase LIN-code extraction needs an API species and scheme. Select a preset with '
+                f"--entero-preset ({'/'.join(ENTEROBASE_PRESET)}), or set both --entero-species and "
+                '--entero-scheme explicitly.'
+            )
+        return species, scheme, hiercc_field
+
+    def _entero_preset_values(self) -> dict[str, str]:
+        """
+        Looks up the selected EnteroBase preset's values, validating the preset name.
+        :return: The preset's values, or an empty dict if no preset was selected
+        """
+        if not self._entero_preset:
+            return {}
+        if self._entero_preset not in ENTEROBASE_PRESET:
+            raise errors.LinCodeError(
+                f"Unknown EnteroBase preset '{self._entero_preset}' (known presets: {', '.join(ENTEROBASE_PRESET)})"
+            )
+        return ENTEROBASE_PRESET[self._entero_preset]
 
 
 def _find_metadata_value(metadata: dict[str, str], candidate_keys: list[str], required: bool = True) -> str | None:
@@ -245,12 +290,15 @@ def _entero_hiercc_thresholds(hiercc: dict[str, Any]) -> list[int]:
     return sorted(distances, reverse=True)
 
 
-def _entero_species_scheme(url: str) -> tuple[str, str]:
+def _select_hiercc(info: dict[str, Any], hiercc_field: str | None) -> dict[str, Any]:
     """
-    Attempts to guess the EnteroBase species and scheme name from the URL (unreliable!).
-    :param url: Scheme URL
-    :return: (species, scheme) API slugs
+    Selects the hierCC object to derive LIN-code thresholds from. The preset-specified (or CLI-overridden) field
+    is used when present; otherwise - no preset matched, or that field is missing from the response - 'hierCCv0'
+    is preferred over 'hierCC' ('hierCCv0' is the original pass EnteroBase mapped LIN codes from).
+    :param info: The 'info' object of an EnteroBase ST API response
+    :param hiercc_field: Preferred hierCC field name ('hierCC'/'hierCCv0'), or None to choose heuristically
+    :return: The selected hierCC object (empty dict if neither field is present)
     """
-    segment = next(s for s in reversed(furl(url).path.segments) if s)
-    species_part, scheme_part = segment.split('.', 1)
-    return species_part.lower(), re.sub(r'v(\d+)$', r'_v\1', scheme_part)
+    if hiercc_field and info.get(hiercc_field):
+        return info[hiercc_field]
+    return info.get('hierCCv0') or info.get('hierCC', {})

--- a/mist/scripts/mistlincode.py
+++ b/mist/scripts/mistlincode.py
@@ -1,0 +1,254 @@
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from furl import furl
+
+from mist.app import NAME_DB_INFO, errors
+from mist.app.loggers.logger import logger
+from mist.app.utils import restutils
+
+URL_ENTEROBASE_API = 'https://enterobase.warwick.ac.uk/api/v2.0'
+
+
+class MistLinCode:
+    """
+    Extracts LIN codes for the best-matching profile in a `mist call` JSON output.
+
+    LIN codes come from profile metadata for BIGSdb databases or the EnteroBase API for EnteroBase databases.
+    Cached bin thresholds determine how many LIN-code positions can be reliably assigned, returning both the full and
+    partially masked codes.
+    """
+
+    def __init__(
+        self,
+        dir_db: Path,
+        entero_token: str | None = None,
+        entero_species: str | None = None,
+        entero_scheme: str | None = None,
+    ) -> None:
+        """
+        Initializes the extractor.
+        :param dir_db: Database directory (indexed by `mist index`)
+        :param entero_token: EnteroBase API token
+        :param entero_species: EnteroBase API species name
+        :param entero_scheme: EnteroBase API scheme name
+        :return: None
+        """
+        self._entero_token = entero_token
+        self._entero_species = entero_species
+        self._entero_scheme = entero_scheme
+        path_db_info = dir_db / NAME_DB_INFO
+        if not path_db_info.exists():
+            raise errors.LinCodeError(
+                f"'{NAME_DB_INFO}' not found in {dir_db} - LIN-code extraction needs to know which source "
+                f"the database came from, so it must have been downloaded with 'mist download'"
+            )
+        with path_db_info.open() as handle:
+            self._db_info: dict[str, Any] = json.load(handle)
+
+    def run(self, path_mist_json: Path, path_out: Path) -> None:
+        """
+        Extracts the LIN code for the best-matching profile in a `mist call` JSON output file, and writes the
+        result to a JSON file.
+        :param path_mist_json: Path to the `mist call` JSON output
+        :param path_out: LIN-code output JSON file
+        :return: None
+        """
+        with path_mist_json.open() as handle:
+            data_mist = json.load(handle)
+        result = self.extract(data_mist)
+
+        with path_out.open('w') as handle:
+            json.dump(result, handle, indent=2)
+
+        if result['lincode_partial'] is not None:
+            rendered = '-'.join(v if v is not None else '*' for v in result['lincode_partial'])
+            logger.info(f"Extracted LIN code for ST {result['st']}: {rendered}")
+        else:
+            logger.info(f"No LIN code for ST {result['st']}")
+
+    def extract(self, data_mist: dict[str, Any]) -> dict[str, Any]:
+        """
+        Extracts the LIN code for the best-matching profile in a `mist call` result.
+        :param data_mist: Parsed `mist call` JSON output
+        :return: LIN-code result
+        """
+        profiles = data_mist.get('profiles')
+        if not profiles:
+            raise errors.LinCodeError('No matching profile found in the input - LIN code cannot be determined')
+        if len(profiles) > 1:
+            logger.warning('Multiple equivalent matching profiles found - using the first one')
+        profile = profiles[0]
+
+        downloader = self._db_info.get('downloader')
+        if downloader in ('bigsdb', 'bigsdb_auth'):
+            return self._extract_bigsdb(profile)
+        if downloader == 'enterobase':
+            return self._extract_enterobase(profile)
+        raise errors.LinCodeError(f"LIN-code extraction is not supported for downloader '{downloader}'")
+
+    def _extract_bigsdb(self, profile: dict[str, Any]) -> dict[str, Any]:
+        """
+        Extracts the LIN code for a BIGSdb-sourced profile.
+        :param profile: Best-matching profile (from the `mist call` JSON output)
+        :return: LIN-code result
+        """
+        metadata = dict(profile['metadata'])
+        lincode_full = _split_lincode(_find_metadata_value(metadata, ['lincode', 'lin_code', 'lin code']))
+
+        lincodes = self._db_info.get('lincodes')
+        if not lincodes:
+            raise errors.LinCodeError(
+                f"'{NAME_DB_INFO}' has no cached LIN-code thresholds. The scheme at {self._db_info['url']} "
+                "may not define them, or this database was downloaded with an older MiST version. "
+                f"Re-run 'mist download' to refresh {NAME_DB_INFO}."
+            )
+        thresholds = [int(t) for t in lincodes['thresholds'].split(';')]
+
+        nb_matches, nb_loci = profile['nb_matches'], len(profile['alleles'])
+        nb_diff = nb_loci - nb_matches
+        bin_assigned = _determine_bin(nb_diff, thresholds)
+        lincode_partial = _mask_lincode(lincode_full, bin_assigned)
+
+        fields = {}
+        for field in lincodes.get('fields', []):
+            name = field['field']
+            fields[name] = _find_metadata_value(metadata, [name], required=False)
+
+        return {
+            'st': profile['name'],
+            'nb_matches': nb_matches,
+            'nb_loci': nb_loci,
+            'lincode_full': lincode_full,
+            'lincode_partial': lincode_partial,
+            'fields': fields,
+        }
+
+    def _extract_enterobase(self, profile: dict[str, Any]) -> dict[str, Any]:
+        """
+        Extracts the LIN code for an EnteroBase-sourced profile via the EnteroBase API. The bin thresholds needed to
+        mask the LIN code come from the ST's hierCC distances.
+        :param profile: Best-matching profile
+        :return: LIN-code result
+        """
+        if not self._entero_token:
+            raise errors.LinCodeError('An EnteroBase API token is required to extract LIN codes for this database')
+
+        species_guess, scheme_guess = _entero_species_scheme(self._db_info['url'])
+        species = self._entero_species or species_guess
+        scheme = self._entero_scheme or scheme_guess
+        st_id = profile['name']
+        url = f'{URL_ENTEROBASE_API}/{species}/{scheme}/sts?limit=1&offset=0&st_id={st_id}&scheme={scheme}'
+        sts = restutils.retrieve_page_data(url, auth=(self._entero_token, '')).json().get('STs', [])
+        if not sts:
+            raise errors.LinCodeError(
+                f"No LIN code found for ST {st_id} at {url} - the species/scheme slug ('{species}'/'{scheme}') "
+                f"may be wrong for this database; override with --entero-species/--entero-scheme if so "
+                f"(EnteroBase's API naming doesn't reliably match its download URLs)"
+            )
+        info = sts[0]['info']
+        lincode_full = _split_lincode(info['lin_code'])
+        nb_matches, nb_loci = profile['nb_matches'], len(profile['alleles'])
+
+        # Prefer 'hierCCv0' over 'hierCC'
+        hiercc_raw = info.get('hierCCv0') or info.get('hierCC', {})
+        thresholds = _entero_hiercc_thresholds(hiercc_raw)
+        if len(thresholds) == len(lincode_full):
+            nb_assigned = _determine_bin(nb_loci - nb_matches, thresholds)
+            lincode_partial = _mask_lincode(lincode_full, nb_assigned)
+        else:
+            logger.warning(
+                f'hierCC thresholds ({len(thresholds)}) do not match the LIN code length '
+                f'({len(lincode_full)}) for ST {st_id} - returning the LIN code unmasked'
+            )
+            lincode_partial = None
+
+        return {
+            'st': st_id,
+            'nb_matches': nb_matches,
+            'nb_loci': nb_loci,
+            'lincode_full': lincode_full,
+            'lincode_partial': lincode_partial,
+        }
+
+
+def _find_metadata_value(metadata: dict[str, str], candidate_keys: list[str], required: bool = True) -> str | None:
+    """
+    Looks up a metadata value by a case-insensitive match against a list of candidate keys.
+    :param metadata: Profile metadata
+    :param candidate_keys: Candidate keys to try, case-insensitively
+    :param required: If True, raises when no candidate key is found
+    :return: Metadata value, or None if not found and not required
+    """
+    by_lower = {k.lower(): v for k, v in metadata.items()}
+    for candidate in candidate_keys:
+        if candidate.lower() in by_lower:
+            return by_lower[candidate.lower()]
+    if required:
+        raise errors.LinCodeError(f'None of the expected metadata field(s) {candidate_keys} found in profile metadata')
+    return None
+
+
+def _split_lincode(lincode: str) -> list[str]:
+    """
+    Splits a LIN code string into its positions, regardless of whether the source uses '_' or '-' separators.
+    :param lincode: LIN code string
+    :return: LIN code positions
+    """
+    return re.split(r'[_-]', lincode)
+
+
+def _determine_bin(nb_diff: int, thresholds: list[int]) -> int:
+    """
+    Determines the number of leading LIN-code positions that can be reliably assigned, given a descending
+    list of per-position mismatch thresholds (thresholds[i] is the max. nb. of mismatches for which position
+    i remains reliably assignable) and the number of mismatches to the best-matching profile.
+    :param nb_diff: Number of mismatching loci
+    :param thresholds: Per-position mismatch-count thresholds, descending
+    :return: Nb. of reliably assignable leading positions
+    """
+    for i, threshold in enumerate(thresholds):
+        if threshold < nb_diff:
+            return i
+    return len(thresholds)
+
+
+def _mask_lincode(lincode_full: list[str], nb_assigned: int) -> list[str | None]:
+    """
+    Masks LIN-code positions beyond the reliably assignable ones with None.
+    :param lincode_full: Full LIN code, as a list of position values
+    :param nb_assigned: Nb. of reliably assignable leading positions (from `_determine_bin`)
+    :return: Partial LIN code, same length as `lincode_full`
+    """
+    return [(value if i < nb_assigned else None) for i, value in enumerate(lincode_full)]
+
+
+def _entero_hiercc_thresholds(hiercc: dict[str, Any]) -> list[int]:
+    """
+    Parses EnteroBase's hierCC distances (the 'dNNN' keys of a ST's 'hierCC'/'hierCCv0' field, e.g. 'd0',
+    'd2', 'd2850') into a descending list of mismatch-count thresholds, equivalent to BIGSdb's LIN-code
+    thresholds. 'd0' (identical profile, i.e. 100% LIN-code similarity) is kept - EnteroBase's documented
+    per-species threshold tables (see the 'LIN codes' wiki page) list it as the deepest real level, not a
+    sentinel to discard.
+    :param hiercc: The 'hierCC' (or 'hierCCv0') object from an EnteroBase ST API response
+    :return: Mismatch-count thresholds, descending
+    """
+    distances = []
+    for key in hiercc:
+        match = re.fullmatch(r'd(\d+)', key)
+        if match:
+            distances.append(int(match.group(1)))
+    return sorted(distances, reverse=True)
+
+
+def _entero_species_scheme(url: str) -> tuple[str, str]:
+    """
+    Attempts to guess the EnteroBase species and scheme name from the URL (unreliable!).
+    :param url: Scheme URL
+    :return: (species, scheme) API slugs
+    """
+    segment = next(s for s in reversed(furl(url).path.segments) if s)
+    species_part, scheme_part = segment.split('.', 1)
+    return species_part.lower(), re.sub(r'v(\d+)$', r'_v\1', scheme_part)

--- a/mist/scripts/mistlincode.py
+++ b/mist/scripts/mistlincode.py
@@ -123,6 +123,7 @@ class MistLinCode:
             'nb_loci': nb_loci,
             'lincode_full': lincode_full,
             'lincode_partial': lincode_partial,
+            'thresholds': thresholds,
             'fields': fields,
         }
 
@@ -171,6 +172,7 @@ class MistLinCode:
             'nb_loci': nb_loci,
             'lincode_full': lincode_full,
             'lincode_partial': lincode_partial,
+            'thresholds': thresholds,
         }
 
 

--- a/mist/tests/cli/test_dists.py
+++ b/mist/tests/cli/test_dists.py
@@ -160,9 +160,12 @@ class TestDists(unittest.TestCase):
                 cli,
                 [
                     'dists',
-                    '--input-list', str(path_input_list),
-                    '--out-dists', str(path_out_dists),
-                    '--out-matrix', str(path_out_matrix),
+                    '--input-list',
+                    str(path_input_list),
+                    '--out-dists',
+                    str(path_out_dists),
+                    '--out-matrix',
+                    str(path_out_matrix),
                 ],
                 catch_exceptions=False,
             )

--- a/mist/tests/cli/test_index.py
+++ b/mist/tests/cli/test_index.py
@@ -1,10 +1,15 @@
+import json
+import shutil
 import unittest
 from importlib.resources import files
 from pathlib import Path
+from unittest.mock import Mock
 
 from click.testing import CliRunner
 
+from mist.app import model
 from mist.app.loggers.logger import initialize_logging, logger
+from mist.app.query.profileindex import ProfileIndex
 from mist.app.utils import dbutils, testingutils
 from mist.scripts.cli import cli
 
@@ -124,6 +129,120 @@ class TestIndex(unittest.TestCase):
             logger.info(result.output)
             self.assertTrue(dbutils.is_valid_db(Path(dir_temp)))
             self.assertEqual(result.exit_code, 0)
+
+    def test_index_copies_db_info_from_profiles_dir(self) -> None:
+        """
+        Tests that db_info.json next to --profiles (but not next to the FASTA files) still gets copied to the
+        output directory.
+        :return: None
+        """
+        runner = CliRunner()
+        with testingutils.get_temp_dir() as dir_temp, testingutils.get_temp_dir() as dir_profiles:
+            dir_temp, dir_profiles = Path(dir_temp), Path(dir_profiles)
+
+            # Place profiles.tsv and db_info.json together, separate from the FASTA files
+            path_profiles_test = str(files('mist').joinpath('resources/testdata/profiles.tsv'))
+            shutil.copyfile(path_profiles_test, dir_profiles / 'profiles.tsv')
+            db_info = {'url': 'https://example.org/scheme', 'downloader': 'bigsdb', 'download_date': '2026-08-10'}
+            with (dir_profiles / 'db_info.json').open('w') as handle:
+                json.dump(db_info, handle)
+
+            # noinspection PyTypeChecker
+            result = runner.invoke(
+                cli,
+                [
+                    'index',
+                    str(files('mist').joinpath('resources/testdata/NEIS0140-subset.fasta')),
+                    str(files('mist').joinpath('resources/testdata/NEIS0159-subset.fasta')),
+                    '--profiles',
+                    str(dir_profiles / 'profiles.tsv'),
+                    '--output',
+                    str(dir_temp),
+                    '--threads',
+                    '4',
+                ],
+                catch_exceptions=False,
+            )
+            logger.info(result.output)
+            self.assertEqual(result.exit_code, 0)
+
+            path_db_info_out = dir_temp / 'db_info.json'
+            self.assertTrue(path_db_info_out.exists())
+            with path_db_info_out.open() as handle:
+                self.assertEqual(db_info, json.load(handle))
+
+    def test_index_without_build_profile_index_skips_it(self) -> None:
+        """
+        Tests that no profile index is built unless --build-profile-index is passed, even with --profiles set.
+        :return: None
+        """
+        runner = CliRunner()
+        with testingutils.get_temp_dir() as dir_temp:
+            # noinspection PyTypeChecker
+            result = runner.invoke(
+                cli,
+                [
+                    'index',
+                    str(files('mist').joinpath('resources/testdata/NEIS0140-subset.fasta')),
+                    str(files('mist').joinpath('resources/testdata/NEIS0159-subset.fasta')),
+                    '--profiles',
+                    str(files('mist').joinpath('resources/testdata/profiles.tsv')),
+                    '--output',
+                    str(dir_temp),
+                    '--threads',
+                    '4',
+                ],
+                catch_exceptions=False,
+            )
+            logger.info(result.output)
+            self.assertEqual(result.exit_code, 0)
+            self.assertFalse((Path(dir_temp) / 'profile_index').exists())
+
+    def test_index_with_build_profile_index_builds_queryable_index(self) -> None:
+        """
+        Tests that --build-profile-index builds a profile index that returns the correct matching ST.
+        :return: None
+        """
+        runner = CliRunner()
+        with testingutils.get_temp_dir() as dir_temp:
+            # noinspection PyTypeChecker
+            result = runner.invoke(
+                cli,
+                [
+                    'index',
+                    str(files('mist').joinpath('resources/testdata/NEIS0140-subset.fasta')),
+                    str(files('mist').joinpath('resources/testdata/NEIS0159-subset.fasta')),
+                    '--profiles',
+                    str(files('mist').joinpath('resources/testdata/profiles.tsv')),
+                    '--output',
+                    str(dir_temp),
+                    '--threads',
+                    '4',
+                    '--build-profile-index',
+                ],
+                catch_exceptions=False,
+            )
+            logger.info(result.output)
+            self.assertEqual(result.exit_code, 0)
+
+            dir_profile_index = Path(dir_temp) / 'profile_index'
+            self.assertTrue(dir_profile_index.exists())
+
+            # ST1 in profiles.tsv is NEIS0140-subset=10, NEIS0159-subset=67
+            result_locus1 = Mock(spec=model.QueryResult)
+            result_locus1.allele_str = '10'
+            result_locus1.allele_results = [Mock()]
+            result_locus2 = Mock(spec=model.QueryResult)
+            result_locus2.allele_str = '67'
+            result_locus2.allele_results = [Mock()]
+
+            profile_idx = ProfileIndex(dir_index=dir_profile_index)
+            profiles, nb_matches = profile_idx.query(
+                {'NEIS0140-subset': result_locus1, 'NEIS0159-subset': result_locus2}
+            )
+            self.assertEqual(len(profiles), 1)
+            self.assertEqual(profiles[0].name, 'ST1')
+            self.assertEqual(nb_matches, 2)
 
 
 if __name__ == '__main__':

--- a/mist/tests/test_lincode.py
+++ b/mist/tests/test_lincode.py
@@ -155,6 +155,7 @@ class TestMistLinCode(unittest.TestCase):
         self.assertEqual('4362', result['st'])
         self.assertEqual(['0', '0', '369', '0', '0', '0', '0', '35', '0', '0'], result['lincode_full'])
         self.assertEqual(['0', '0', '369', '0', '0', '0', '0', None, None, None], result['lincode_partial'])
+        self.assertEqual([629, 610, 585, 190, 43, 10, 7, 4, 2, 1], result['thresholds'])
         self.assertEqual({'Phylogroup': 'KpI'}, result['fields'])
 
     def test_run_writes_output_file(self) -> None:
@@ -192,6 +193,7 @@ class TestMistLinCode(unittest.TestCase):
         self.assertEqual('4362', result['st'])
         self.assertEqual(['0', '0', '369', '0', '0', '0', '0', '35', '0', '0'], result['lincode_full'])
         self.assertEqual(['0', '0', '369', '0', '0', '0', '0', None, None, None], result['lincode_partial'])
+        self.assertEqual([629, 610, 585, 190, 43, 10, 7, 4, 2, 1], result['thresholds'])
 
     def test_extract_bigsdb_missing_cached_thresholds_raises(self) -> None:
         """
@@ -255,6 +257,8 @@ class TestMistLinCode(unittest.TestCase):
         self.assertEqual(['0', '0', '3', '0', '0', '0', '0', '3', '3', '7', '0', '0', '0'], result['lincode_full'])
         expected_partial = ['0', '0', '3', '0', '0', '0', '0', '3', '3', '7', '0', None, None]
         self.assertEqual(expected_partial, result['lincode_partial'])
+        expected_thresholds = [2850, 2600, 2000, 900, 400, 200, 100, 50, 20, 10, 5, 2, 0]
+        self.assertEqual(expected_thresholds, result['thresholds'])
 
         # Confirm the mocked call targeted the derived species/scheme slugs, authenticated with the token
         called_args, called_kwargs = mock_retrieve.call_args
@@ -321,6 +325,8 @@ class TestMistLinCode(unittest.TestCase):
         self.assertEqual(expected_full, result['lincode_full'])
         expected_partial = ['0', '0', '0', '0', '2', '89', '0', '0', '4', None, None, None, None]
         self.assertEqual(expected_partial, result['lincode_partial'])
+        expected_thresholds = [2350, 2000, 1500, 1100, 400, 200, 100, 50, 20, 10, 5, 2, 0]
+        self.assertEqual(expected_thresholds, result['thresholds'])
 
     @patch('mist.scripts.mistlincode.restutils.retrieve_page_data')
     def test_extract_enterobase_without_matching_hiercc_falls_back_unmasked(self, mock_retrieve: Mock) -> None:
@@ -343,6 +349,7 @@ class TestMistLinCode(unittest.TestCase):
             result = MistLinCode(dir_db=dir_temp, entero_token='dummy-token').extract({'profiles': [profile]})
 
         self.assertIsNone(result['lincode_partial'])
+        self.assertEqual([2, 0], result['thresholds'])
 
     def test_extract_enterobase_without_token_raises(self) -> None:
         """

--- a/mist/tests/test_lincode.py
+++ b/mist/tests/test_lincode.py
@@ -9,7 +9,6 @@ from mist.scripts.mistlincode import (
     MistLinCode,
     _determine_bin,
     _entero_hiercc_thresholds,
-    _entero_species_scheme,
     _mask_lincode,
 )
 
@@ -48,15 +47,6 @@ class TestLinCodeHelpers(unittest.TestCase):
         nb_assigned = _determine_bin(5, self.THRESHOLDS)
         masked = _mask_lincode(self.LINCODE_FULL, nb_assigned)
         self.assertEqual(['0', '0', '369', '0', '0', '0', '0', None, None, None], masked)
-
-    def test_entero_species_scheme(self) -> None:
-        """
-        Tests deriving the EnteroBase API species/scheme slugs from a scheme download URL.
-        :return: None
-        """
-        species, scheme = _entero_species_scheme('https://enterobase.warwick.ac.uk/schemes/Senterica.cgMLSTv2/')
-        self.assertEqual('senterica', species)
-        self.assertEqual('cgMLST_v2', scheme)
 
     def test_entero_hiercc_thresholds(self) -> None:
         """
@@ -235,8 +225,8 @@ class TestMistLinCode(unittest.TestCase):
     def test_extract_enterobase_with_hiercc_thresholds(self, mock_retrieve: Mock) -> None:
         """
         Tests extracting a partial LIN code for an EnteroBase-sourced profile, masked using hierCCv0-derived
-        thresholds - 'hierCCv0' is preferred over the longer 'hierCC' (see ENTERO_INFO), and its 13 thresholds
-        (including d0 as the deepest, 100%-similarity level) match the 13-position LIN code, so masking
+        thresholds - the 'salmonella' preset pins the hierCC field to 'hierCCv0' (see ENTERO_INFO), and its 13
+        thresholds (including d0 as the deepest, 100%-similarity level) match the 13-position LIN code, so masking
         applies. Real-world example (ST 102245, senterica/cgMLST_v2, 3 mismatches): the threshold for the
         second-deepest position (2) is exceeded, so the two deepest positions are masked.
         :return: None
@@ -251,7 +241,9 @@ class TestMistLinCode(unittest.TestCase):
                 downloader='enterobase',
                 url='https://enterobase.warwick.ac.uk/schemes/Senterica.cgMLSTv2/',
             )
-            result = MistLinCode(dir_db=dir_temp, entero_token='dummy-token').extract({'profiles': [profile]})
+            result = MistLinCode(
+                dir_db=dir_temp, entero_token='dummy-token', entero_preset='salmonella'
+            ).extract({'profiles': [profile]})
 
         self.assertEqual('102245', result['st'])
         self.assertEqual(['0', '0', '3', '0', '0', '0', '0', '3', '3', '7', '0', '0', '0'], result['lincode_full'])
@@ -268,8 +260,8 @@ class TestMistLinCode(unittest.TestCase):
     @patch('mist.scripts.mistlincode.restutils.retrieve_page_data')
     def test_extract_enterobase_species_scheme_override(self, mock_retrieve: Mock) -> None:
         """
-        Tests that explicit entero_species/entero_scheme override the (unreliable) auto-derived guess - e.g.
-        E. coli needs 'ecoli'/'cgMLST', not the 'escherichia'/'cgMLST_v1' guessed from its download URL.
+        Tests that explicit entero_species/entero_scheme pin the queried endpoint without a preset - the API
+        endpoint is built from the overrides alone, not guessed from the download URL.
         :return: None
         """
         mock_retrieve.return_value.json.return_value = {'STs': [{'ST_id': '146609', 'info': self.ENTERO_INFO}]}
@@ -290,13 +282,73 @@ class TestMistLinCode(unittest.TestCase):
         self.assertIn('/ecoli/cgMLST/sts', called_url)
 
     @patch('mist.scripts.mistlincode.restutils.retrieve_page_data')
+    def test_extract_enterobase_preset_override_scheme(self, mock_retrieve: Mock) -> None:
+        """
+        Tests that an individual override wins over the selected preset - the 'salmonella' preset supplies the
+        species ('senterica') and hierCC field, while --entero-scheme overrides just the scheme.
+        :return: None
+        """
+        mock_retrieve.return_value.json.return_value = {'STs': [{'ST_id': '102245', 'info': self.ENTERO_INFO}]}
+        profile = {'name': '102245', 'nb_matches': 3000, 'alleles': {f'locus{i}': '1' for i in range(3002)}}
+
+        with testingutils.get_temp_dir() as dir_temp:
+            dir_temp = Path(dir_temp)
+            self._write_db_info(
+                dir_temp,
+                downloader='enterobase',
+                url='https://enterobase.warwick.ac.uk/schemes/Senterica.cgMLSTv2/',
+            )
+            MistLinCode(
+                dir_db=dir_temp, entero_token='dummy-token', entero_preset='salmonella', entero_scheme='cgMLST_v3'
+            ).extract({'profiles': [profile]})
+
+        self.assertIn('/senterica/cgMLST_v3/sts', mock_retrieve.call_args[0][0])
+
+    def test_extract_enterobase_without_preset_or_overrides_raises(self) -> None:
+        """
+        Tests that an EnteroBase extraction with neither a preset nor explicit species/scheme overrides raises,
+        rather than querying a guessed endpoint (URL-based guessing has been removed).
+        :return: None
+        """
+        profile = {'name': '102245', 'nb_matches': 3000, 'alleles': {f'locus{i}': '1' for i in range(3002)}}
+
+        with testingutils.get_temp_dir() as dir_temp:
+            dir_temp = Path(dir_temp)
+            self._write_db_info(
+                dir_temp,
+                downloader='enterobase',
+                url='https://enterobase.warwick.ac.uk/schemes/Senterica.cgMLSTv2/',
+            )
+            with self.assertRaises(LinCodeError):
+                MistLinCode(dir_db=dir_temp, entero_token='dummy-token').extract({'profiles': [profile]})
+
+    def test_extract_enterobase_unknown_preset_raises(self) -> None:
+        """
+        Tests that selecting a preset name that isn't defined raises a clear error.
+        :return: None
+        """
+        profile = {'name': '102245', 'nb_matches': 3000, 'alleles': {f'locus{i}': '1' for i in range(3002)}}
+
+        with testingutils.get_temp_dir() as dir_temp:
+            dir_temp = Path(dir_temp)
+            self._write_db_info(
+                dir_temp,
+                downloader='enterobase',
+                url='https://enterobase.warwick.ac.uk/schemes/Senterica.cgMLSTv2/',
+            )
+            with self.assertRaises(LinCodeError):
+                MistLinCode(
+                    dir_db=dir_temp, entero_token='dummy-token', entero_preset='klebsiella'
+                ).extract({'profiles': [profile]})
+
+    @patch('mist.scripts.mistlincode.restutils.retrieve_page_data')
     def test_extract_enterobase_falls_back_to_hiercc_without_v0(self, mock_retrieve: Mock) -> None:
         """
-        Tests the real E. coli case: no 'hierCCv0' field at all (unlike Salmonella), so 'hierCC' is used
-        directly. E. coli's 'hierCC' has 13 raw keys already matching EnteroBase's documented 13-level
-        mapping (no extra level like Salmonella's 'd150'), so once d0 is kept as the deepest threshold, it
-        lines up with the 13-position LIN code and masking applies - this used to always fall back to
-        unmasked before d0 was included. Real-world example (ST 268260, ecoli/cgMLST, 11 mismatches).
+        Tests the real E. coli case: the 'ecoli' preset pins the hierCC field to 'hierCC' (E. coli has no
+        'hierCCv0' field at all, unlike Salmonella). E. coli's 'hierCC' has 13 raw keys already matching
+        EnteroBase's documented 13-level mapping (no extra level like Salmonella's 'd150'), so once d0 is kept
+        as the deepest threshold, it lines up with the 13-position LIN code and masking applies. Real-world
+        example (ST 268260, ecoli/cgMLST, 11 mismatches).
         :return: None
         """
         info = {
@@ -318,7 +370,7 @@ class TestMistLinCode(unittest.TestCase):
                 url='https://enterobase.warwick.ac.uk/schemes/Escherichia.cgMLSTv1/',
             )
             result = MistLinCode(
-                dir_db=dir_temp, entero_token='dummy-token', entero_species='ecoli', entero_scheme='cgMLST'
+                dir_db=dir_temp, entero_token='dummy-token', entero_preset='ecoli'
             ).extract({'profiles': [profile]})
 
         expected_full = ['0', '0', '0', '0', '2', '89', '0', '0', '4', '0', '2', '1', '36']
@@ -346,7 +398,9 @@ class TestMistLinCode(unittest.TestCase):
                 downloader='enterobase',
                 url='https://enterobase.warwick.ac.uk/schemes/Senterica.cgMLSTv2/',
             )
-            result = MistLinCode(dir_db=dir_temp, entero_token='dummy-token').extract({'profiles': [profile]})
+            result = MistLinCode(
+                dir_db=dir_temp, entero_token='dummy-token', entero_preset='salmonella'
+            ).extract({'profiles': [profile]})
 
         self.assertIsNone(result['lincode_partial'])
         self.assertEqual([2, 0], result['thresholds'])

--- a/mist/tests/test_lincode.py
+++ b/mist/tests/test_lincode.py
@@ -1,0 +1,362 @@
+import json
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from mist.app.errors import LinCodeError
+from mist.app.utils import testingutils
+from mist.scripts.mistlincode import (
+    MistLinCode,
+    _determine_bin,
+    _entero_hiercc_thresholds,
+    _entero_species_scheme,
+    _mask_lincode,
+)
+
+
+class TestLinCodeHelpers(unittest.TestCase):
+    """
+    Tests for the pure LIN-code helper functions.
+    """
+
+    # Real thresholds/LIN code for the Klebsiella scgMLST629_S scheme (10 positions).
+    THRESHOLDS = [629, 610, 585, 190, 43, 10, 7, 4, 2, 1]
+    LINCODE_FULL = ['0', '0', '369', '0', '0', '0', '0', '35', '0', '0']
+
+    def test_determine_bin(self) -> None:
+        """
+        Tests that the number of assignable positions matches the known Klebsiella example (5 mismatches):
+        position 6 (threshold 7) still tolerates 5 mismatches, position 7 (threshold 4) does not, so 7
+        leading positions (indices 0-6) are assignable.
+        :return: None
+        """
+        self.assertEqual(7, _determine_bin(5, self.THRESHOLDS))
+
+    def test_determine_bin_exact_match(self) -> None:
+        """
+        Tests that zero mismatches assigns every position, including the deepest one.
+        :return: None
+        """
+        self.assertEqual(len(self.THRESHOLDS), _determine_bin(0, self.THRESHOLDS))
+
+    def test_mask_lincode_matches_known_example(self) -> None:
+        """
+        Tests that masking with the known example's assignable-position count reproduces the documented
+        partial LIN code.
+        :return: None
+        """
+        nb_assigned = _determine_bin(5, self.THRESHOLDS)
+        masked = _mask_lincode(self.LINCODE_FULL, nb_assigned)
+        self.assertEqual(['0', '0', '369', '0', '0', '0', '0', None, None, None], masked)
+
+    def test_entero_species_scheme(self) -> None:
+        """
+        Tests deriving the EnteroBase API species/scheme slugs from a scheme download URL.
+        :return: None
+        """
+        species, scheme = _entero_species_scheme('https://enterobase.warwick.ac.uk/schemes/Senterica.cgMLSTv2/')
+        self.assertEqual('senterica', species)
+        self.assertEqual('cgMLST_v2', scheme)
+
+    def test_entero_hiercc_thresholds(self) -> None:
+        """
+        Tests parsing hierCC distances (real EnteroBase example) into descending thresholds, keeping d0 as
+        the deepest (100%-similarity) level.
+        :return: None
+        """
+        hiercc = {
+            'd0': '102245', 'd2': '102245', 'd5': '102245', 'd10': '102245', 'd20': '78391', 'd50': '4323',
+            'd100': '36', 'd150': '36', 'd200': '36', 'd400': '36', 'd900': '36', 'd2000': '36', 'd2600': '2',
+            'd2850': '2',
+        }
+        self.assertEqual(
+            [2850, 2600, 2000, 900, 400, 200, 150, 100, 50, 20, 10, 5, 2, 0], _entero_hiercc_thresholds(hiercc)
+        )
+
+
+class TestMistLinCode(unittest.TestCase):
+    """
+    Tests for the `MistLinCode` class.
+    """
+
+    def _write_db_info(
+        self, dir_db: Path, downloader: str, url: str, lincodes: dict[str, object] | None = None
+    ) -> None:
+        """
+        Writes a minimal `db_info.json` file, as produced by `mist download`.
+        :param dir_db: Database directory
+        :param downloader: Downloader key
+        :param url: Scheme URL
+        :param lincodes: Cached LIN-code thresholds/fields, as fetched at download time for BIGSdb sources
+        :return: None
+        """
+        data = {'url': url, 'downloader': downloader, 'download_date': '2026-08-10T00:00:00'}
+        if lincodes is not None:
+            data['lincodes'] = lincodes
+        with (dir_db / 'db_info.json').open('w') as handle:
+            json.dump(data, handle)
+
+    def test_missing_db_info_raises(self) -> None:
+        """
+        Tests that a database without db_info.json raises a clear error.
+        :return: None
+        """
+        with testingutils.get_temp_dir() as dir_temp:
+            with self.assertRaises(LinCodeError):
+                MistLinCode(dir_db=Path(dir_temp))
+
+    def test_no_matching_profile_raises(self) -> None:
+        """
+        Tests that an input with no matching profile raises a clear error.
+        :return: None
+        """
+        with testingutils.get_temp_dir() as dir_temp:
+            dir_temp = Path(dir_temp)
+            self._write_db_info(dir_temp, downloader='bigsdb', url='https://example.org/scheme')
+            extractor = MistLinCode(dir_db=dir_temp)
+            with self.assertRaises(LinCodeError):
+                extractor.extract({'profiles': None})
+
+    def test_unsupported_downloader_raises(self) -> None:
+        """
+        Tests that a downloader without LIN-code support raises a clear error.
+        :return: None
+        """
+        with testingutils.get_temp_dir() as dir_temp:
+            dir_temp = Path(dir_temp)
+            self._write_db_info(dir_temp, downloader='cgmlstorg', url='https://example.org/scheme')
+            extractor = MistLinCode(dir_db=dir_temp)
+            with self.assertRaises(LinCodeError):
+                extractor.extract({'profiles': [{'name': 'ST1', 'metadata': [], 'alleles': {}}]})
+
+    def test_extract_bigsdb(self) -> None:
+        """
+        Tests extracting a partial LIN code for a BIGSdb-sourced profile end-to-end, using LIN-code thresholds
+        cached in `db_info.json` at download time (no live API call needed for BIGSdb extraction).
+        :return: None
+        """
+        lincodes = {
+            'thresholds': '629;610;585;190;43;10;7;4;2;1',
+            'fields': [{'field': 'Phylogroup'}],
+        }
+        profile = {
+            'name': '4362',
+            'nb_matches': 624,
+            'alleles': {f'locus{i}': '1' for i in range(629)},
+            'metadata': [['LINcode', '0_0_369_0_0_0_0_35_0_0'], ['Phylogroup', 'KpI']],
+        }
+
+        with testingutils.get_temp_dir() as dir_temp:
+            dir_temp = Path(dir_temp)
+            url = 'https://bigsdb.pasteur.fr/api/db/pubmlst_klebsiella_seqdef/schemes/18'
+            self._write_db_info(dir_temp, downloader='bigsdb', url=url, lincodes=lincodes)
+            result = MistLinCode(dir_db=dir_temp).extract({'profiles': [profile]})
+
+        self.assertEqual('4362', result['st'])
+        self.assertEqual(['0', '0', '369', '0', '0', '0', '0', '35', '0', '0'], result['lincode_full'])
+        self.assertEqual(['0', '0', '369', '0', '0', '0', '0', None, None, None], result['lincode_partial'])
+        self.assertEqual({'Phylogroup': 'KpI'}, result['fields'])
+
+    def test_run_writes_output_file(self) -> None:
+        """
+        Tests that `run` reads the `mist call` JSON input, extracts the LIN code, and writes the result to
+        the output JSON file (the same result `extract` would return directly).
+        :return: None
+        """
+        lincodes = {
+            'thresholds': '629;610;585;190;43;10;7;4;2;1',
+            'fields': [{'field': 'Phylogroup'}],
+        }
+        profile = {
+            'name': '4362',
+            'nb_matches': 624,
+            'alleles': {f'locus{i}': '1' for i in range(629)},
+            'metadata': [['LINcode', '0_0_369_0_0_0_0_35_0_0'], ['Phylogroup', 'KpI']],
+        }
+
+        with testingutils.get_temp_dir() as dir_temp:
+            dir_temp = Path(dir_temp)
+            url = 'https://bigsdb.pasteur.fr/api/db/pubmlst_klebsiella_seqdef/schemes/18'
+            self._write_db_info(dir_temp, downloader='bigsdb', url=url, lincodes=lincodes)
+
+            path_mist_json = dir_temp / 'mist.json'
+            with path_mist_json.open('w') as handle:
+                json.dump({'profiles': [profile]}, handle)
+            path_out = dir_temp / 'lincode.json'
+
+            MistLinCode(dir_db=dir_temp).run(path_mist_json, path_out)
+
+            with path_out.open() as handle:
+                result = json.load(handle)
+
+        self.assertEqual('4362', result['st'])
+        self.assertEqual(['0', '0', '369', '0', '0', '0', '0', '35', '0', '0'], result['lincode_full'])
+        self.assertEqual(['0', '0', '369', '0', '0', '0', '0', None, None, None], result['lincode_partial'])
+
+    def test_extract_bigsdb_missing_cached_thresholds_raises(self) -> None:
+        """
+        Tests that a BIGSdb-sourced database without cached LIN-code thresholds (e.g. downloaded before this
+        was cached, or a scheme that doesn't define them) raises a clear, actionable error instead of trying
+        a live API call.
+        :return: None
+        """
+        profile = {
+            'name': '4362',
+            'nb_matches': 624,
+            'alleles': {f'locus{i}': '1' for i in range(629)},
+            'metadata': [['LINcode', '0_0_369_0_0_0_0_35_0_0']],
+        }
+        with testingutils.get_temp_dir() as dir_temp:
+            dir_temp = Path(dir_temp)
+            self._write_db_info(dir_temp, downloader='bigsdb', url='https://example.org/scheme')
+            with self.assertRaises(LinCodeError):
+                MistLinCode(dir_db=dir_temp).extract({'profiles': [profile]})
+
+    # Real EnteroBase example response (ST 102245, senterica/cgMLST_v2). 'hierCC' is the current pass, which
+    # has since picked up an extra 'd150' level (14 raw keys) not part of EnteroBase's documented 13-level
+    # LIN-code mapping; 'hierCCv0' is the original pass LIN codes were mapped from and matches that mapping
+    # exactly (13 raw keys, no 'd150').
+    ENTERO_INFO = {
+        'lin_code': '0-0-3-0-0-0-0-3-3-7-0-0-0',
+        'hierCC': {
+            'd0': '102245', 'd2': '102245', 'd5': '102245', 'd10': '102245', 'd20': '78391', 'd50': '4323',
+            'd100': '36', 'd150': '36', 'd200': '36', 'd400': '36', 'd900': '36', 'd2000': '36', 'd2600': '2',
+            'd2850': '2',
+        },
+        'hierCCv0': {
+            'd0': '102245', 'd2': '102245', 'd5': '102245', 'd10': '102245', 'd20': '78391', 'd50': '4323',
+            'd100': '36', 'd200': '36', 'd400': '36', 'd900': '36', 'd2000': '36', 'd2600': '2', 'd2850': '2',
+        },
+    }
+
+    @patch('mist.scripts.mistlincode.restutils.retrieve_page_data')
+    def test_extract_enterobase_with_hiercc_thresholds(self, mock_retrieve: Mock) -> None:
+        """
+        Tests extracting a partial LIN code for an EnteroBase-sourced profile, masked using hierCCv0-derived
+        thresholds - 'hierCCv0' is preferred over the longer 'hierCC' (see ENTERO_INFO), and its 13 thresholds
+        (including d0 as the deepest, 100%-similarity level) match the 13-position LIN code, so masking
+        applies. Real-world example (ST 102245, senterica/cgMLST_v2, 3 mismatches): the threshold for the
+        second-deepest position (2) is exceeded, so the two deepest positions are masked.
+        :return: None
+        """
+        mock_retrieve.return_value.json.return_value = {'STs': [{'ST_id': '102245', 'info': self.ENTERO_INFO}]}
+        profile = {'name': '102245', 'nb_matches': 2999, 'alleles': {f'locus{i}': '1' for i in range(3002)}}
+
+        with testingutils.get_temp_dir() as dir_temp:
+            dir_temp = Path(dir_temp)
+            self._write_db_info(
+                dir_temp,
+                downloader='enterobase',
+                url='https://enterobase.warwick.ac.uk/schemes/Senterica.cgMLSTv2/',
+            )
+            result = MistLinCode(dir_db=dir_temp, entero_token='dummy-token').extract({'profiles': [profile]})
+
+        self.assertEqual('102245', result['st'])
+        self.assertEqual(['0', '0', '3', '0', '0', '0', '0', '3', '3', '7', '0', '0', '0'], result['lincode_full'])
+        expected_partial = ['0', '0', '3', '0', '0', '0', '0', '3', '3', '7', '0', None, None]
+        self.assertEqual(expected_partial, result['lincode_partial'])
+
+        # Confirm the mocked call targeted the derived species/scheme slugs, authenticated with the token
+        called_args, called_kwargs = mock_retrieve.call_args
+        self.assertIn('/senterica/cgMLST_v2/sts', called_args[0])
+        self.assertEqual(('dummy-token', ''), called_kwargs['auth'])
+
+    @patch('mist.scripts.mistlincode.restutils.retrieve_page_data')
+    def test_extract_enterobase_species_scheme_override(self, mock_retrieve: Mock) -> None:
+        """
+        Tests that explicit entero_species/entero_scheme override the (unreliable) auto-derived guess - e.g.
+        E. coli needs 'ecoli'/'cgMLST', not the 'escherichia'/'cgMLST_v1' guessed from its download URL.
+        :return: None
+        """
+        mock_retrieve.return_value.json.return_value = {'STs': [{'ST_id': '146609', 'info': self.ENTERO_INFO}]}
+        profile = {'name': '146609', 'nb_matches': 3000, 'alleles': {f'locus{i}': '1' for i in range(3002)}}
+
+        with testingutils.get_temp_dir() as dir_temp:
+            dir_temp = Path(dir_temp)
+            self._write_db_info(
+                dir_temp,
+                downloader='enterobase',
+                url='https://enterobase.warwick.ac.uk/schemes/Escherichia.cgMLSTv1/',
+            )
+            MistLinCode(
+                dir_db=dir_temp, entero_token='dummy-token', entero_species='ecoli', entero_scheme='cgMLST'
+            ).extract({'profiles': [profile]})
+
+        called_url = mock_retrieve.call_args[0][0]
+        self.assertIn('/ecoli/cgMLST/sts', called_url)
+
+    @patch('mist.scripts.mistlincode.restutils.retrieve_page_data')
+    def test_extract_enterobase_falls_back_to_hiercc_without_v0(self, mock_retrieve: Mock) -> None:
+        """
+        Tests the real E. coli case: no 'hierCCv0' field at all (unlike Salmonella), so 'hierCC' is used
+        directly. E. coli's 'hierCC' has 13 raw keys already matching EnteroBase's documented 13-level
+        mapping (no extra level like Salmonella's 'd150'), so once d0 is kept as the deepest threshold, it
+        lines up with the 13-position LIN code and masking applies - this used to always fall back to
+        unmasked before d0 was included. Real-world example (ST 268260, ecoli/cgMLST, 11 mismatches).
+        :return: None
+        """
+        info = {
+            'lin_code': '0-0-0-0-2-89-0-0-4-0-2-1-36',
+            'hierCC': {
+                'd0': '268260', 'd2': '151557', 'd5': '142807', 'd10': '109409', 'd20': '109409',
+                'd50': '71026', 'd100': '71026', 'd200': '71026', 'd400': '37', 'd1100': '13', 'd1500': '5',
+                'd2000': '2', 'd2350': '1',
+            },
+        }
+        mock_retrieve.return_value.json.return_value = {'STs': [{'ST_id': '268260', 'info': info}]}
+        profile = {'name': '268260', 'nb_matches': 2502, 'alleles': {f'locus{i}': '1' for i in range(2513)}}
+
+        with testingutils.get_temp_dir() as dir_temp:
+            dir_temp = Path(dir_temp)
+            self._write_db_info(
+                dir_temp,
+                downloader='enterobase',
+                url='https://enterobase.warwick.ac.uk/schemes/Escherichia.cgMLSTv1/',
+            )
+            result = MistLinCode(
+                dir_db=dir_temp, entero_token='dummy-token', entero_species='ecoli', entero_scheme='cgMLST'
+            ).extract({'profiles': [profile]})
+
+        expected_full = ['0', '0', '0', '0', '2', '89', '0', '0', '4', '0', '2', '1', '36']
+        self.assertEqual(expected_full, result['lincode_full'])
+        expected_partial = ['0', '0', '0', '0', '2', '89', '0', '0', '4', None, None, None, None]
+        self.assertEqual(expected_partial, result['lincode_partial'])
+
+    @patch('mist.scripts.mistlincode.restutils.retrieve_page_data')
+    def test_extract_enterobase_without_matching_hiercc_falls_back_unmasked(self, mock_retrieve: Mock) -> None:
+        """
+        Tests that a hierCC/LIN-code length mismatch falls back to an unmasked LIN code, rather than masking
+        with a threshold count that doesn't correspond to the actual LIN-code positions.
+        :return: None
+        """
+        info = {'lin_code': '0-0-3-0-0-0-0-3-3-7-0-0-0', 'hierCC': {'d0': '102245', 'd2': '102245'}}
+        mock_retrieve.return_value.json.return_value = {'STs': [{'ST_id': '102245', 'info': info}]}
+        profile = {'name': '102245', 'nb_matches': 3000, 'alleles': {f'locus{i}': '1' for i in range(3002)}}
+
+        with testingutils.get_temp_dir() as dir_temp:
+            dir_temp = Path(dir_temp)
+            self._write_db_info(
+                dir_temp,
+                downloader='enterobase',
+                url='https://enterobase.warwick.ac.uk/schemes/Senterica.cgMLSTv2/',
+            )
+            result = MistLinCode(dir_db=dir_temp, entero_token='dummy-token').extract({'profiles': [profile]})
+
+        self.assertIsNone(result['lincode_partial'])
+
+    def test_extract_enterobase_without_token_raises(self) -> None:
+        """
+        Tests that extracting a LIN code for an EnteroBase-sourced profile without a token raises clearly.
+        :return: None
+        """
+        profile = {'name': '102245', 'nb_matches': 3000, 'alleles': {f'locus{i}': '1' for i in range(3002)}}
+
+        with testingutils.get_temp_dir() as dir_temp:
+            dir_temp = Path(dir_temp)
+            self._write_db_info(
+                dir_temp,
+                downloader='enterobase',
+                url='https://enterobase.warwick.ac.uk/schemes/Senterica.cgMLSTv2/',
+            )
+            with self.assertRaises(LinCodeError):
+                MistLinCode(dir_db=dir_temp).extract({'profiles': [profile]})

--- a/mist/tests/test_lincode.py
+++ b/mist/tests/test_lincode.py
@@ -55,8 +55,19 @@ class TestLinCodeHelpers(unittest.TestCase):
         :return: None
         """
         hiercc = {
-            'd0': '102245', 'd2': '102245', 'd5': '102245', 'd10': '102245', 'd20': '78391', 'd50': '4323',
-            'd100': '36', 'd150': '36', 'd200': '36', 'd400': '36', 'd900': '36', 'd2000': '36', 'd2600': '2',
+            'd0': '102245',
+            'd2': '102245',
+            'd5': '102245',
+            'd10': '102245',
+            'd20': '78391',
+            'd50': '4323',
+            'd100': '36',
+            'd150': '36',
+            'd200': '36',
+            'd400': '36',
+            'd900': '36',
+            'd2000': '36',
+            'd2600': '2',
             'd2850': '2',
         }
         self.assertEqual(
@@ -211,13 +222,35 @@ class TestMistLinCode(unittest.TestCase):
     ENTERO_INFO = {
         'lin_code': '0-0-3-0-0-0-0-3-3-7-0-0-0',
         'hierCC': {
-            'd0': '102245', 'd2': '102245', 'd5': '102245', 'd10': '102245', 'd20': '78391', 'd50': '4323',
-            'd100': '36', 'd150': '36', 'd200': '36', 'd400': '36', 'd900': '36', 'd2000': '36', 'd2600': '2',
+            'd0': '102245',
+            'd2': '102245',
+            'd5': '102245',
+            'd10': '102245',
+            'd20': '78391',
+            'd50': '4323',
+            'd100': '36',
+            'd150': '36',
+            'd200': '36',
+            'd400': '36',
+            'd900': '36',
+            'd2000': '36',
+            'd2600': '2',
             'd2850': '2',
         },
         'hierCCv0': {
-            'd0': '102245', 'd2': '102245', 'd5': '102245', 'd10': '102245', 'd20': '78391', 'd50': '4323',
-            'd100': '36', 'd200': '36', 'd400': '36', 'd900': '36', 'd2000': '36', 'd2600': '2', 'd2850': '2',
+            'd0': '102245',
+            'd2': '102245',
+            'd5': '102245',
+            'd10': '102245',
+            'd20': '78391',
+            'd50': '4323',
+            'd100': '36',
+            'd200': '36',
+            'd400': '36',
+            'd900': '36',
+            'd2000': '36',
+            'd2600': '2',
+            'd2850': '2',
         },
     }
 
@@ -241,9 +274,9 @@ class TestMistLinCode(unittest.TestCase):
                 downloader='enterobase',
                 url='https://enterobase.warwick.ac.uk/schemes/Senterica.cgMLSTv2/',
             )
-            result = MistLinCode(
-                dir_db=dir_temp, entero_token='dummy-token', entero_preset='salmonella'
-            ).extract({'profiles': [profile]})
+            result = MistLinCode(dir_db=dir_temp, entero_token='dummy-token', entero_preset='salmonella').extract(
+                {'profiles': [profile]}
+            )
 
         self.assertEqual('102245', result['st'])
         self.assertEqual(['0', '0', '3', '0', '0', '0', '0', '3', '3', '7', '0', '0', '0'], result['lincode_full'])
@@ -337,9 +370,9 @@ class TestMistLinCode(unittest.TestCase):
                 url='https://enterobase.warwick.ac.uk/schemes/Senterica.cgMLSTv2/',
             )
             with self.assertRaises(LinCodeError):
-                MistLinCode(
-                    dir_db=dir_temp, entero_token='dummy-token', entero_preset='klebsiella'
-                ).extract({'profiles': [profile]})
+                MistLinCode(dir_db=dir_temp, entero_token='dummy-token', entero_preset='klebsiella').extract(
+                    {'profiles': [profile]}
+                )
 
     @patch('mist.scripts.mistlincode.restutils.retrieve_page_data')
     def test_extract_enterobase_falls_back_to_hiercc_without_v0(self, mock_retrieve: Mock) -> None:
@@ -354,9 +387,19 @@ class TestMistLinCode(unittest.TestCase):
         info = {
             'lin_code': '0-0-0-0-2-89-0-0-4-0-2-1-36',
             'hierCC': {
-                'd0': '268260', 'd2': '151557', 'd5': '142807', 'd10': '109409', 'd20': '109409',
-                'd50': '71026', 'd100': '71026', 'd200': '71026', 'd400': '37', 'd1100': '13', 'd1500': '5',
-                'd2000': '2', 'd2350': '1',
+                'd0': '268260',
+                'd2': '151557',
+                'd5': '142807',
+                'd10': '109409',
+                'd20': '109409',
+                'd50': '71026',
+                'd100': '71026',
+                'd200': '71026',
+                'd400': '37',
+                'd1100': '13',
+                'd1500': '5',
+                'd2000': '2',
+                'd2350': '1',
             },
         }
         mock_retrieve.return_value.json.return_value = {'STs': [{'ST_id': '268260', 'info': info}]}
@@ -369,9 +412,9 @@ class TestMistLinCode(unittest.TestCase):
                 downloader='enterobase',
                 url='https://enterobase.warwick.ac.uk/schemes/Escherichia.cgMLSTv1/',
             )
-            result = MistLinCode(
-                dir_db=dir_temp, entero_token='dummy-token', entero_preset='ecoli'
-            ).extract({'profiles': [profile]})
+            result = MistLinCode(dir_db=dir_temp, entero_token='dummy-token', entero_preset='ecoli').extract(
+                {'profiles': [profile]}
+            )
 
         expected_full = ['0', '0', '0', '0', '2', '89', '0', '0', '4', '0', '2', '1', '36']
         self.assertEqual(expected_full, result['lincode_full'])
@@ -398,9 +441,9 @@ class TestMistLinCode(unittest.TestCase):
                 downloader='enterobase',
                 url='https://enterobase.warwick.ac.uk/schemes/Senterica.cgMLSTv2/',
             )
-            result = MistLinCode(
-                dir_db=dir_temp, entero_token='dummy-token', entero_preset='salmonella'
-            ).extract({'profiles': [profile]})
+            result = MistLinCode(dir_db=dir_temp, entero_token='dummy-token', entero_preset='salmonella').extract(
+                {'profiles': [profile]}
+            )
 
         self.assertIsNone(result['lincode_partial'])
         self.assertEqual([2, 0], result['thresholds'])

--- a/mist/tests/test_profile_index.py
+++ b/mist/tests/test_profile_index.py
@@ -1,3 +1,4 @@
+import unittest
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -6,7 +7,6 @@ import pandas as pd
 from mist.app import model
 from mist.app.query.profileindex import ProfileIndex
 from mist.app.utils import testingutils
-import unittest
 
 
 class TestProfileIndex(unittest.TestCase):

--- a/mist/tests/test_profile_index.py
+++ b/mist/tests/test_profile_index.py
@@ -1,0 +1,138 @@
+from pathlib import Path
+from unittest.mock import Mock
+
+import pandas as pd
+
+from mist.app import model
+from mist.app.query.profileindex import ProfileIndex
+from mist.app.utils import testingutils
+import unittest
+
+
+class TestProfileIndex(unittest.TestCase):
+    """
+    Contains tests for performing profile queries using the index.
+    """
+
+    TEST_PROFILES = [
+        {'ST': 'ST1', 'locus1': '1', 'locus2': '1', 'locus3': '1'},
+        {'ST': 'ST2', 'locus1': '2', 'locus2': 'N', 'locus3': '2'},
+        {'ST': 'ST2_alt', 'locus1': '2', 'locus2': '2', 'locus3': 'N'},
+        {'ST': 'ST3', 'locus1': '3', 'locus2': 'N', 'locus3': 'N'},
+        {'ST': 'ST4', 'locus1': '4', 'locus2': 'N', 'locus3': 'N'},
+    ]
+
+    def test_query_returns_best_matching_profiles(self) -> None:
+        """
+        Tests the query method returns the best matching profiles.
+        :return: None
+        """
+        with testingutils.get_temp_dir() as dir_temp:
+            dir_temp = Path(dir_temp)
+
+            # Create the profiles file
+            path_profiles = dir_temp / "profiles.tsv"
+            pd.DataFrame(TestProfileIndex.TEST_PROFILES).to_csv(path_profiles, sep='\t', index=False)
+
+            # Create query results
+            result_locus1 = Mock(spec=model.QueryResult)
+            result_locus1.allele_str = "1"
+            result_locus1.allele_results = [Mock()]
+
+            result_locus2 = Mock(spec=model.QueryResult)
+            result_locus2.allele_str = "1"
+            result_locus2.allele_results = [Mock()]
+
+            result_locus3 = Mock(spec=model.QueryResult)
+            result_locus3.allele_str = "1"
+            result_locus3.allele_results = [Mock()]
+
+            result_by_locus = {
+                "locus1": result_locus1,
+                "locus2": result_locus2,
+                "locus3": result_locus3,
+            }
+
+            # Query the profiles
+            pi = ProfileIndex(
+                path_profiles=path_profiles, loci=list(result_by_locus.keys()), dir_out=dir_temp / "index"
+            )
+            profiles, nb_matches = pi.query(result_by_locus)
+
+            # Assertions
+            self.assertEqual(len(profiles), 1)
+            self.assertEqual(profiles[0].name, "ST1")
+            self.assertEqual(nb_matches, 3)
+
+    def test_query_returns_multiple_best_matching_profiles(self) -> None:
+        """
+        Tests the query method returns the best matching profiles (multiple).
+        :return: None
+        """
+        with testingutils.get_temp_dir() as dir_temp:
+            dir_temp = Path(dir_temp)
+
+            # Create the profiles file
+            path_profiles = dir_temp / "profiles.tsv"
+            pd.DataFrame(TestProfileIndex.TEST_PROFILES).to_csv(path_profiles, sep='\t', index=False)
+
+            # Create query results
+            result_locus1 = Mock(spec=model.QueryResult)
+            result_locus1.allele_str = "2"
+            result_locus1.allele_results = [Mock()]
+
+            result_locus2 = Mock(spec=model.QueryResult)
+            result_locus2.allele_str = "2"
+            result_locus2.allele_results = [Mock()]
+
+            result_locus3 = Mock(spec=model.QueryResult)
+            result_locus3.allele_str = "2"
+            result_locus3.allele_results = [Mock()]
+
+            result_by_locus = {
+                "locus1": result_locus1,
+                "locus2": result_locus2,
+                "locus3": result_locus3,
+            }
+
+            # Query the profiles
+            pi = ProfileIndex(
+                path_profiles=path_profiles, loci=list(result_by_locus.keys()), dir_out=dir_temp / "index"
+            )
+            profiles, nb_matches = pi.query(result_by_locus)
+
+            # Assertions
+            self.assertEqual(len(profiles), 2)
+            self.assertIn("ST2", [p.name for p in profiles])
+            self.assertIn("ST2_alt", [p.name for p in profiles])
+            self.assertEqual(nb_matches, 3)
+
+    def test_build_and_reload_index_returns_same_result(self) -> None:
+        """
+        Tests that a built index, once reloaded, returns the same query result as the original.
+        :return: None
+        """
+        with testingutils.get_temp_dir() as dir_temp:
+            dir_temp = Path(dir_temp)
+
+            # Create the profiles file
+            path_profiles = dir_temp / "profiles.tsv"
+            pd.DataFrame(TestProfileIndex.TEST_PROFILES).to_csv(path_profiles, sep='\t', index=False)
+
+            # Create query results
+            result_locus1 = Mock(spec=model.QueryResult)
+            result_locus1.allele_str = "1"
+            result_locus1.allele_results = [Mock()]
+
+            result_by_locus = {"locus1": result_locus1}
+
+            # Build and reload the index
+            dir_index = dir_temp / "index"
+            ProfileIndex(path_profiles=path_profiles, loci=["locus1", "locus2", "locus3"], dir_out=dir_index)
+            pi_reloaded = ProfileIndex(dir_index=dir_index)
+
+            # Assertions
+            profiles, nb_matches = pi_reloaded.query(result_by_locus)
+            self.assertEqual(len(profiles), 1)
+            self.assertEqual(profiles[0].name, "ST1")
+            self.assertEqual(nb_matches, 1)

--- a/mist/tests/utils/test_allele_utils.py
+++ b/mist/tests/utils/test_allele_utils.py
@@ -1,0 +1,53 @@
+import unittest
+from unittest.mock import Mock
+
+from mist.app import model
+from mist.app.utils import alleleutils
+
+
+class TestAlleleUtils(unittest.TestCase):
+    """
+    Tests for the allele utilities.
+    """
+
+    def test_encode_decode_allele_round_trip(self) -> None:
+        """
+        Tests that encoding and decoding an allele returns the original value.
+        :return: None
+        """
+        for allele in ['0', '1', '42', model.ALLELE_WILDCARD]:
+            self.assertEqual(allele, alleleutils.decode_allele(alleleutils.encode_allele(allele)))
+
+    def test_encode_allele_unreadable(self) -> None:
+        """
+        Tests that a non-numeric, non-wildcard allele is encoded as unreadable.
+        :return: None
+        """
+        self.assertEqual(alleleutils.CODE_UNREADABLE, alleleutils.encode_allele('n/a'))
+
+    def test_candidate_codes_no_result(self) -> None:
+        """
+        Tests that a locus without a detected result yields the absent code.
+        :return: None
+        """
+        self.assertEqual({alleleutils.CODE_ABSENT}, alleleutils.candidate_codes(None))
+
+    def test_candidate_codes_single_hit(self) -> None:
+        """
+        Tests that a single detected allele yields its own code.
+        :return: None
+        """
+        res = Mock(spec=model.QueryResult)
+        res.allele_str = '5'
+        res.allele_results = [Mock()]
+        self.assertEqual({5}, alleleutils.candidate_codes(res))
+
+    def test_candidate_codes_multi_hit_drops_novel_marker(self) -> None:
+        """
+        Tests that multiple detected alleles yield each code, and a novel-allele marker is dropped.
+        :return: None
+        """
+        res = Mock(spec=model.QueryResult)
+        res.allele_str = '5__12*'
+        res.allele_results = [Mock(), Mock()]
+        self.assertEqual({5}, alleleutils.candidate_codes(res))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ version = {attr = "mist.version.__version__"}
   "resources/citation.txt",
   "resources/pubmlst/download_bigsdb.py",
   "resources/testdata/*.fasta",
+  "resources/testdata/profiles.tsv",
   "resources/testdata/output/*.tsv",
   "resources/testdata/output/*.json"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "bs4",
   "click",
   "furl",
+  "numpy",
   "pandas",
   "pytest",
   "pytest-xdist",


### PR DESCRIPTION
## Summary

Adds support for calculating LIN codes with MiST, along with a rewritten profile-matching algorithm that scales to large cgMLST schemes.
The proof-of-concept `mist_to_partial_lincode.py` script, which was originally developed for _Klebsiella_, was used as the starting point but was then extended to be scheme-agnostic.

## What's new

- **`mist lincode` command** — extracts LIN codes offline for BIGSdb-hosted schemes (PubMLST, Institut Pasteur), and via API calls for EnteroBase. Reported thresholds are included in the output.
- **Scalable profile index** — replaces the in-memory, string-based matcher (which ran out of memory on large cgMLST schemes) with:
  - integer-encoded alleles (handling wildcards and missing alleles),
  - a reverse index (locus_allele → profile) turning matching into a counting problem,
  - a numpy memmap backend with multithreading and vectorization to avoid loading all profiles into memory.
- **Downloader** now stores LIN-code information when available, with authorization support for BIGSdb. - requires re-building (downloading & indexing) the DB!